### PR TITLE
name logger

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ To customize the default ratelimiter, for example to send at a rate of 35 reques
 ```python
 import logging
 import naz
-logger = logging.getLogger()
+logger = logging.getLogger("naz.rateLimiter")
 
 myLimiter = naz.ratelimiter.SimpleRateLimiter(logger=logger, send_rate=35)
 cli = naz.Client(

--- a/cli/cli.py
+++ b/cli/cli.py
@@ -102,7 +102,7 @@ def main():
     )
 
     extra_log_data = {"log_metadata": log_metadata}
-    logger = logging.getLogger()
+    logger = logging.getLogger("naz.cli")
     handler = logging.StreamHandler()
     formatter = logging.Formatter("%(message)s")
     handler.setFormatter(formatter)

--- a/naz/__version__.py
+++ b/naz/__version__.py
@@ -2,7 +2,7 @@ about = {
     "__title__": "naz",
     "__description__": "Naz is an SMPP client.",
     "__url__": "https://github.com/komuw/naz",
-    "__version__": "0.0.2",
+    "__version__": "0.0.3",
     "__author__": "komuW",
     "__author_email__": "komuw05@gmail.com",
     "__license__": "MIT",

--- a/naz/client.py
+++ b/naz/client.py
@@ -268,7 +268,7 @@ class Client:
 
         # NB: currently, naz only uses to log levels; INFO and EXCEPTION
         extra_log_data = {"log_metadata": self.log_metadata}
-        self.logger = logging.getLogger()
+        self.logger = logging.getLogger("naz.client")
         handler = logging.StreamHandler()
         formatter = logging.Formatter("%(message)s")
         handler.setFormatter(formatter)

--- a/naz/ratelimiter.py
+++ b/naz/ratelimiter.py
@@ -29,8 +29,8 @@ class SimpleRateLimiter(BaseRateLimiter):
     def __init__(
         self,
         logger: logging.Logger,
-        send_rate: float = 1000,
-        max_tokens: float = 1000,
+        send_rate: float = 100000,
+        max_tokens: float = 100000,
         delay_for_tokens: float = 1,
     ) -> None:
         """

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -255,7 +255,7 @@ class TestClient(TestCase):
 
     def test_no_sending_if_throttler(self):
         with mock.patch("naz.q.SimpleOutboundQueue.dequeue", new=AsyncMock()) as mock_naz_dequeue:
-            logger = logging.getLogger()
+            logger = logging.getLogger("naz.test")
             handler = logging.StreamHandler()
             formatter = logging.Formatter("%(message)s")
             handler.setFormatter(formatter)

--- a/tests/test_ratelimit.py
+++ b/tests/test_ratelimit.py
@@ -34,7 +34,7 @@ class TestRateLimit(TestCase):
     def setUp(self):
         self.loop = asyncio.get_event_loop()
 
-        self.logger = logging.getLogger()
+        self.logger = logging.getLogger("naz.test")
         handler = logging.StreamHandler()
         formatter = logging.Formatter("%(message)s")
         handler.setFormatter(formatter)

--- a/tests/test_throttle.py
+++ b/tests/test_throttle.py
@@ -23,7 +23,7 @@ class TestThrottle(TestCase):
     def setUp(self):
         self.loop = asyncio.get_event_loop()
 
-        self.logger = logging.getLogger()
+        self.logger = logging.getLogger("naz.test")
         handler = logging.StreamHandler()
         formatter = logging.Formatter("%(message)s")
         handler.setFormatter(formatter)


### PR DESCRIPTION
look at: https://www.electricmonk.nl/log/2017/08/06/understanding-pythons-logging-module/

if you dont use a name; you configure the root logger without knowing
logger = logging.getLogger()
logger.warning('l')
  WARNING:root:l

logger = logging.getLogger('naz.client')
logger.warning('only naz')
   WARNING:naz.client:only naz

Thank you for contributing to naz.                    
Every contribution to naz is important.                       

                     

Contributor offers to license certain software (a “Contribution” or multiple
“Contributions”) to naz, and naz agrees to accept said Contributions,
under the terms of the MIT License.
Contributor understands and agrees that naz shall have the irrevocable and perpetual right to make
and distribute copies of any Contribution, as well as to create and distribute collective works and
derivative works of any Contribution, under the MIT License.


Now,                   

## What(What have you changed?)


## Why(Why did you change it?)

