### PR TITLE
eliminate correlation_id=None

### DIFF
--- a/examples/example_klasses.py
+++ b/examples/example_klasses.py
@@ -146,7 +146,7 @@ if __name__ == "__main__":
             "version": "1",
             "smpp_event": "submit_sm",
             "short_message": "Hello World-{0}".format(str(i)),
-            "correlation_id": "myid12345",
+            "correlation_id": "myid1234-{0}".format(str(i)),
             "source_addr": "254722111111",
             "destination_addr": "254722999999",
         }

--- a/naz/client.py
+++ b/naz/client.py
@@ -57,7 +57,7 @@ class Client:
         registered_delivery=0b00000101,  # see section 5.2.17
         replace_if_present_flag=0x00000000,
         sm_default_msg_id=0x00000000,
-        enquire_link_interval=90,
+        enquire_link_interval=300,
         loglevel="DEBUG",
         log_metadata=None,
         codec_class=None,

--- a/naz/client.py
+++ b/naz/client.py
@@ -375,7 +375,7 @@ class Client:
         self.logger.info({"event": "naz.Client.tranceiver_bind", "stage": "end"})
         return full_pdu
 
-    async def enquire_link(self, correlation_id, TESTING=False):
+    async def enquire_link(self, TESTING=False):
         """
         HEADER::
         # enquire_link has the following pdu header:
@@ -387,6 +387,7 @@ class Client:
         `enquire_link` has no body.
         """
         while True:
+            correlation_id = "".join(random.choices(string.ascii_lowercase + string.digits, k=17))
             self.logger.info(
                 {
                     "event": "naz.Client.enquire_link",
@@ -724,8 +725,6 @@ class Client:
                     sequence_number, self.max_sequence_number
                 )
             )
-        # associate sequence_number and user supplied correlation_id
-        self.seq_correl[sequence_number] = correlation_id
         header = struct.pack(">IIII", command_length, command_id, command_status, sequence_number)
         full_pdu = header + body
 
@@ -748,6 +747,11 @@ class Client:
         """
         # todo: look at `set_write_buffer_limits` and `get_write_buffer_limits` methods
         # print("get_write_buffer_limits:", writer.transport.get_write_buffer_limits())
+
+        # associate sequence_number and correlation_id.
+        # this will enable us to also associate responses and thus enhancing traceability of all workflows
+        self.seq_correl[sequence_number] = correlation_id
+
         log_msg = ""
         try:
             log_msg = self.codec_class.decode(msg, self.encoding)

--- a/naz/client.py
+++ b/naz/client.py
@@ -375,7 +375,7 @@ class Client:
         self.logger.info({"event": "naz.Client.tranceiver_bind", "stage": "end"})
         return full_pdu
 
-    async def enquire_link(self, correlation_id=None, TESTING=False):
+    async def enquire_link(self, correlation_id, TESTING=False):
         """
         HEADER::
         # enquire_link has the following pdu header:
@@ -437,7 +437,7 @@ class Client:
                 return full_pdu
             await asyncio.sleep(self.enquire_link_interval)
 
-    async def enquire_link_resp(self, sequence_number, correlation_id=None):
+    async def enquire_link_resp(self, sequence_number, correlation_id):
         """
         HEADER::
         # enquire_link_resp has the following pdu header:
@@ -491,7 +491,7 @@ class Client:
             }
         )
 
-    async def unbind_resp(self, sequence_number, correlation_id=None):
+    async def unbind_resp(self, sequence_number, correlation_id):
         """
         HEADER::
         # unbind_resp has the following pdu header:
@@ -523,7 +523,7 @@ class Client:
             {"event": "naz.Client.unbind_resp", "stage": "end", "correlation_id": correlation_id}
         )
 
-    async def deliver_sm_resp(self, sequence_number, correlation_id=None):
+    async def deliver_sm_resp(self, sequence_number, correlation_id):
         """
         HEADER::
         # deliver_sm_resp has the following pdu header:
@@ -741,7 +741,7 @@ class Client:
         )
         return full_pdu
 
-    async def send_data(self, smpp_event, msg, correlation_id=None):
+    async def send_data(self, smpp_event, msg, correlation_id):
         """
         This method does not block; it buffers the data and arranges for it to be sent out asynchronously.
         see: https://docs.python.org/3/library/asyncio-stream.html#asyncio.StreamWriter.write
@@ -1155,7 +1155,7 @@ class Client:
                 }
             )
 
-    async def unbind(self, correlation_id=None):
+    async def unbind(self, correlation_id):
         """
         HEADER::
         # unbind has the following pdu header:

--- a/naz/client.py
+++ b/naz/client.py
@@ -363,6 +363,9 @@ class Client:
         command_status = self.command_statuses["ESME_ROK"].code
         try:
             sequence_number = self.sequence_generator.next_sequence()
+            # associate sequence_number with correlation_id.
+            # this will enable us to also associate responses and thus enhancing traceability of all workflows
+            self.seq_correl[sequence_number] = correlation_id
         except Exception as e:
             self.logger.exception(
                 {"event": "naz.Client.tranceiver_bind", "stage": "end", "error": str(e)}
@@ -419,6 +422,9 @@ class Client:
             command_status = 0x00000000  # not used for `enquire_link`
             try:
                 sequence_number = self.sequence_generator.next_sequence()
+                # associate sequence_number with correlation_id.
+                # this will enable us to also associate responses and thus enhancing traceability of all workflows
+                self.seq_correl[sequence_number] = correlation_id
             except Exception as e:
                 self.logger.exception(
                     {
@@ -730,6 +736,9 @@ class Client:
         command_status = 0x00000000  # not used for `submit_sm`
         try:
             sequence_number = self.sequence_generator.next_sequence()
+            # associate sequence_number with correlation_id.
+            # this will enable us to also associate responses and thus enhancing traceability of all workflows
+            self.seq_correl[sequence_number] = correlation_id
         except Exception as e:
             self.logger.exception(
                 {
@@ -768,10 +777,6 @@ class Client:
         """
         # todo: look at `set_write_buffer_limits` and `get_write_buffer_limits` methods
         # print("get_write_buffer_limits:", writer.transport.get_write_buffer_limits())
-
-        # associate sequence_number with correlation_id.
-        # this will enable us to also associate responses and thus enhancing traceability of all workflows
-        self.seq_correl[sequence_number] = correlation_id
 
         log_msg = ""
         try:
@@ -1202,6 +1207,9 @@ class Client:
         command_status = 0x00000000  # not used for `unbind`
         try:
             sequence_number = self.sequence_generator.next_sequence()
+            # associate sequence_number with correlation_id.
+            # this will enable us to also associate responses and thus enhancing traceability of all workflows
+            self.seq_correl[sequence_number] = correlation_id
         except Exception as e:
             self.logger.exception(
                 {

--- a/naz/client.py
+++ b/naz/client.py
@@ -544,7 +544,7 @@ class Client:
             {"event": "naz.Client.unbind_resp", "stage": "end", "correlation_id": correlation_id}
         )
 
-    async def deliver_sm_resp(self, sequence_number, correlation_id):
+    async def deliver_sm_resp(self, sequence_number):
         """
         HEADER::
         # deliver_sm_resp has the following pdu header:
@@ -556,6 +556,7 @@ class Client:
         BODY::
         message_id, c-octet String, 1octet. This field is unused and is set to NULL.
         """
+        correlation_id = "".join(random.choices(string.ascii_lowercase + string.digits, k=17))
         self.logger.info(
             {
                 "event": "naz.Client.deliver_sm_resp",
@@ -1157,9 +1158,7 @@ class Client:
             # short_message, C-Octet String, 0-254 octet
 
             # NB: user's hook has already been called.
-            await self.deliver_sm_resp(
-                sequence_number=sequence_number, correlation_id=correlation_id
-            )
+            await self.deliver_sm_resp(sequence_number=sequence_number)
         elif smpp_event == "enquire_link":
             # we have to handle this. we have to return enquire_link_resp
             # it has no body

--- a/naz/client.py
+++ b/naz/client.py
@@ -1176,7 +1176,7 @@ class Client:
                 }
             )
 
-    async def unbind(self, correlation_id):
+    async def unbind(self):
         """
         HEADER::
         # unbind has the following pdu header:
@@ -1189,6 +1189,7 @@ class Client:
 
         clients/users should call this method when winding down.
         """
+        correlation_id = "".join(random.choices(string.ascii_lowercase + string.digits, k=17))
         self.logger.info(
             {"event": "naz.Client.unbind", "stage": "start", "correlation_id": correlation_id}
         )
@@ -1221,7 +1222,7 @@ class Client:
 
         full_pdu = header + body
         # dont queue unbind in SimpleOutboundQueue since we dont want it to be behind 10k msgs etc
-        await self.send_data(smpp_event="unbind", msg=full_pdu)
+        await self.send_data(smpp_event="unbind", msg=full_pdu, correlation_id=correlation_id)
         self.logger.info(
             {"event": "naz.Client.unbind", "stage": "end", "correlation_id": correlation_id}
         )

--- a/naz/client.py
+++ b/naz/client.py
@@ -331,7 +331,8 @@ class Client:
         return reader, writer
 
     async def tranceiver_bind(self):
-        self.logger.info({"event": "naz.Client.tranceiver_bind", "stage": "start"})
+        correlation_id = "".join(random.choices(string.ascii_lowercase + string.digits, k=17))
+        self.logger.info({"event": "naz.Client.tranceiver_bind", "stage": "start", "correlation_id": correlation_id})
         # body
         body = b""
         body = (
@@ -371,8 +372,8 @@ class Client:
         header = struct.pack(">IIII", command_length, command_id, command_status, sequence_number)
 
         full_pdu = header + body
-        await self.send_data(smpp_event="bind_transceiver", msg=full_pdu)
-        self.logger.info({"event": "naz.Client.tranceiver_bind", "stage": "end"})
+        await self.send_data(smpp_event="bind_transceiver", msg=full_pdu, correlation_id=correlation_id)
+        self.logger.info({"event": "naz.Client.tranceiver_bind", "stage": "end", "correlation_id":correlation_id})
         return full_pdu
 
     async def enquire_link(self, TESTING=False):
@@ -748,7 +749,7 @@ class Client:
         # todo: look at `set_write_buffer_limits` and `get_write_buffer_limits` methods
         # print("get_write_buffer_limits:", writer.transport.get_write_buffer_limits())
 
-        # associate sequence_number and correlation_id.
+        # associate sequence_number with correlation_id.
         # this will enable us to also associate responses and thus enhancing traceability of all workflows
         self.seq_correl[sequence_number] = correlation_id
 

--- a/naz/client.py
+++ b/naz/client.py
@@ -332,7 +332,13 @@ class Client:
 
     async def tranceiver_bind(self):
         correlation_id = "".join(random.choices(string.ascii_lowercase + string.digits, k=17))
-        self.logger.info({"event": "naz.Client.tranceiver_bind", "stage": "start", "correlation_id": correlation_id})
+        self.logger.info(
+            {
+                "event": "naz.Client.tranceiver_bind",
+                "stage": "start",
+                "correlation_id": correlation_id,
+            }
+        )
         # body
         body = b""
         body = (
@@ -372,8 +378,16 @@ class Client:
         header = struct.pack(">IIII", command_length, command_id, command_status, sequence_number)
 
         full_pdu = header + body
-        await self.send_data(smpp_event="bind_transceiver", msg=full_pdu, correlation_id=correlation_id)
-        self.logger.info({"event": "naz.Client.tranceiver_bind", "stage": "end", "correlation_id":correlation_id})
+        await self.send_data(
+            smpp_event="bind_transceiver", msg=full_pdu, correlation_id=correlation_id
+        )
+        self.logger.info(
+            {
+                "event": "naz.Client.tranceiver_bind",
+                "stage": "end",
+                "correlation_id": correlation_id,
+            }
+        )
         return full_pdu
 
     async def enquire_link(self, TESTING=False):
@@ -427,7 +441,9 @@ class Client:
 
             full_pdu = header + body
             # dont queue enquire_link in SimpleOutboundQueue since we dont want it to be behind 10k msgs etc
-            await self.send_data(smpp_event="enquire_link", msg=full_pdu)
+            await self.send_data(
+                smpp_event="enquire_link", msg=full_pdu, correlation_id=correlation_id
+            )
             self.logger.info(
                 {
                     "event": "naz.Client.enquire_link",
@@ -439,7 +455,7 @@ class Client:
                 return full_pdu
             await asyncio.sleep(self.enquire_link_interval)
 
-    async def enquire_link_resp(self, sequence_number, correlation_id):
+    async def enquire_link_resp(self, sequence_number):
         """
         HEADER::
         # enquire_link_resp has the following pdu header:
@@ -450,7 +466,7 @@ class Client:
 
         `enquire_link_resp` has no body.
         """
-        # body
+        correlation_id = "".join(random.choices(string.ascii_lowercase + string.digits, k=17))
         self.logger.info(
             {
                 "event": "naz.Client.enquire_link_resp",
@@ -458,6 +474,8 @@ class Client:
                 "correlation_id": correlation_id,
             }
         )
+
+        # body
         body = b""
 
         # header
@@ -1144,9 +1162,7 @@ class Client:
         elif smpp_event == "enquire_link":
             # we have to handle this. we have to return enquire_link_resp
             # it has no body
-            await self.enquire_link_resp(
-                sequence_number=sequence_number, correlation_id=correlation_id
-            )
+            await self.enquire_link_resp(sequence_number=sequence_number)
         else:
             self.logger.exception(
                 {

--- a/naz/client.py
+++ b/naz/client.py
@@ -511,7 +511,7 @@ class Client:
             }
         )
 
-    async def unbind_resp(self, sequence_number, correlation_id):
+    async def unbind_resp(self, sequence_number):
         """
         HEADER::
         # unbind_resp has the following pdu header:
@@ -522,6 +522,7 @@ class Client:
 
         `unbind_resp` has no body.
         """
+        correlation_id = "".join(random.choices(string.ascii_lowercase + string.digits, k=17))
         self.logger.info(
             {"event": "naz.Client.unbind_resp", "stage": "start", "correlation_id": correlation_id}
         )
@@ -538,7 +539,7 @@ class Client:
 
         full_pdu = header + body
         # dont queue unbind_resp in SimpleOutboundQueue since we dont want it to be behind 10k msgs etc
-        await self.send_data(smpp_event="unbind_resp", msg=full_pdu)
+        await self.send_data(smpp_event="unbind_resp", msg=full_pdu, correlation_id=correlation_id)
         self.logger.info(
             {"event": "naz.Client.unbind_resp", "stage": "end", "correlation_id": correlation_id}
         )
@@ -1117,7 +1118,7 @@ class Client:
         elif smpp_event == "unbind":
             # we need to handle this since we need to send unbind_resp
             # it has no body
-            await self.unbind_resp(sequence_number=sequence_number, correlation_id=correlation_id)
+            await self.unbind_resp(sequence_number=sequence_number)
         elif smpp_event == "submit_sm_resp":
             # the body of this only has `message_id` which is a C-Octet String of variable length upto 65 octets.
             # This field contains the SMSC message_id of the submitted message.


### PR DESCRIPTION
Thank you for contributing to naz.                    
Every contribution to naz is important.                       

                     

Contributor offers to license certain software (a “Contribution” or multiple
“Contributions”) to naz, and naz agrees to accept said Contributions,
under the terms of the MIT License.
Contributor understands and agrees that naz shall have the irrevocable and perpetual right to make
and distribute copies of any Contribution, as well as to create and distribute collective works and
derivative works of any Contribution, under the MIT License.


Now,                   

# What(What have you changed?)
- eliminate all instances where `eliminate correlation_id==None`
- for `naz.Client.enquire_link` generate a new `correlation_id` for every loop iteration
- in `naz.Client.send_data` associate `sequence_number` with `correlation_id`; this will enable us to also associate responses and thus enhancing traceability of all workflows
- for `naz.Client.tranceiver_bind` generate a `correlation_id` that will get passed to `naz.Client.send_data`
- generate `correlation_id` for `naz.Client.enquire_link_resp`
- generate `correlation_id` for `naz.Client.unbind_resp`
- generate `correlation_id` for `naz.Client.deliver_sm_resp`
- generate correlation_id for `naz.Client.unbind`
- everytime we generate a new `sequence_number` via `client..sequence_generator.next_sequence()`,
    we should associate that `sequence_number` with a corresponding `correlation_id`.
    We cannot offload the work of doing the association to `client.sequence_generator`
    because `client.seq_correl` is in one process while `client.sequence_generator` is in another;
    in fact `client.sequence_generator` maybe be a database in a completely different host from the one running `naz.Client`

# Why(Why did you change it?)
- this will enhance `naz` observability features; this is because we will now be able to associate all requests to SMSC with their corresponding responses(if any)
- closes: https://github.com/komuw/naz/issues/49

# References:
1. 
