### PR TITLE
issues/52 add smpp session states.

### DIFF
--- a/examples/example_config.json
+++ b/examples/example_config.json
@@ -12,6 +12,6 @@
         "release": "canary"
     },
     "codec_errors_level": "ignore",
-    "enquire_link_interval": 420,
+    "enquire_link_interval": 70,
     "rateLimiter": "examples.example_klasses.ExampleRateLimiter"
 }

--- a/naz/client.py
+++ b/naz/client.py
@@ -408,6 +408,10 @@ class Client:
         `enquire_link` has no body.
         """
         while True:
+            if self.current_session_state != SmppSessionState.BOUND_TRX:
+                # you can only send enquire_link request when session state is BOUND_TRX
+                await asyncio.sleep(self.enquire_link_interval)
+
             correlation_id = "".join(random.choices(string.ascii_lowercase + string.digits, k=17))
             self.logger.info(
                 {

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -168,6 +168,8 @@ class TestClient(TestCase):
             }
 
             reader, writer = self._run(self.cli.connect())
+            # hack to allow sending submit_sm even when state is wrong
+            self.cli.current_session_state = "BOUND_TRX"
             self._run(self.cli.send_forever(TESTING=True))
 
             self.assertTrue(mock_naz_dequeue.mock.called)


### PR DESCRIPTION
restrict sending messages to SMSC if the session state is not in correct state

Thank you for contributing to naz.                    
Every contribution to naz is important.                       

                     

Contributor offers to license certain software (a “Contribution” or multiple
“Contributions”) to naz, and naz agrees to accept said Contributions,
under the terms of the MIT License.
Contributor understands and agrees that naz shall have the irrevocable and perpetual right to make
and distribute copies of any Contribution, as well as to create and distribute collective works and
derivative works of any Contribution, under the MIT License.


Now,                   

# What(What have you changed?)
- add smpp session states. restrict sending messages to SMSC if the session state is not in correct state
- in `enquire_link`, if `current_session_state != SmppSessionState.BOUND_TRX` then we should sleep for some time.
- if `current_session_state == SmppSessionState.CLOSED` we should not send any smpp_event to SMSC. The only thing we can do in that state is make a network connection to SMSC(ie `naz.Client.connect`, calling that method will aslo set `current_session_state = SmppSessionState.OPEN` )
- if `current_session_state == SmppSessionState.OPEN` only `bind_transceiver` can be sent to SMSC. 
  All other smpp_event's can only be sent if state==`SmppSessionState.BOUND_TRX`

# Why(Why did you change it?)
- updates: https://github.com/komuw/naz/issues/52

# References:
1. 
