### PR TITLE
change default esm_class

### DIFF
--- a/naz/client.py
+++ b/naz/client.py
@@ -45,7 +45,7 @@ class Client:
         # xxxxxx00 store-and-forward
         # xx0010xx Short Message contains ESME Delivery Acknowledgement
         # 00xxxxxx No specific features selected
-        esm_class=0b00001000,  # section 5.2.12
+        esm_class=0b00000011,  # section 5.2.12
         protocol_id=0x00000000,
         priority_flag=0x00000000,
         schedule_delivery_time="",


### PR DESCRIPTION
Thank you for contributing to naz.                    
Every contribution to naz is important.                       

                     

Contributor offers to license certain software (a “Contribution” or multiple
“Contributions”) to naz, and naz agrees to accept said Contributions,
under the terms of the MIT License.
Contributor understands and agrees that naz shall have the irrevocable and perpetual right to make
and distribute copies of any Contribution, as well as to create and distribute collective works and
derivative works of any Contribution, under the MIT License.


Now,                   

# What(What have you changed?)
- change default `esm_class` from `0b00001000` to `0b00000011`(3 in base10)
- The prevous default  in `naz` before this PR was `0b00001000`(Short Message contains ESME Delivery Acknowledgement)
- The new default is `0b00000011`(Store and Forward mode)

# Why(Why did you change it?)
- kannel defaults[1] to 0b00000011(3 in base10) (Store and Forward mode)
   jasmin[2] also defaults to 0b00000011
   vumi[3] defaults to 0b00000000 [Default SMSC Mode (e.g. Store and Forward)]
- closes: https://github.com/komuw/naz/issues/65

# References:
1. https://www.kannel.org/download/kannel-userguide-snapshot/userguide.html#AEN1851       
2. https://github.com/jookies/jasmin/issues/299       
3. https://github.com/praekeltfoundation/vumi/blob/02518583774bcb4db5472aead02df617e1725997/vumi/transports/smpp/protocol.py#L416