### PR TITLE
Issues/74 - rename correlation_id

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ for i in range(0, 4):
         "version": "1",
         "smpp_command": naz.SmppCommand.SUBMIT_SM,
         "short_message": "Hello World-{0}".format(str(i)),
-        "correlation_id": "myid12345",
+        "log_id": "myid12345",
         "source_addr": "254722111111",
         "destination_addr": "254722999999",
     }
@@ -131,9 +131,9 @@ run:
 {'event': 'naz.Client.connect', 'stage': 'start', 'environment': 'production', 'release': 'canary', 'smsc_host': '127.0.0.1', 'system_id': 'smppclient1', 'client_id': '2VU55VT86KHWXTW7X'}
 {'event': 'naz.Client.connect', 'stage': 'end', 'environment': 'production', 'release': 'canary', 'smsc_host': '127.0.0.1', 'system_id': 'smppclient1', 'client_id': '2VU55VT86KHWXTW7X'}
 {'event': 'naz.Client.tranceiver_bind', 'stage': 'start', 'environment': 'production', 'release': 'canary', 'smsc_host': '127.0.0.1', 'system_id': 'smppclient1', 'client_id': '2VU55VT86KHWXTW7X'}
-{'event': 'naz.Client.send_data', 'stage': 'start', 'smpp_command': 'bind_transceiver', 'correlation_id': None, 'msg': 'hello', 'environment': 'production', 'release': 'canary', 'smsc_host': '127.0.0.1', 'system_id': 'smppclient1', 'client_id': '2VU55VT86KHWXTW7X'}
-{'event': 'naz.SimpleHook.request', 'stage': 'start', 'smpp_command': 'bind_transceiver', 'correlation_id': None, 'environment': 'production', 'release': 'canary', 'smsc_host': '127.0.0.1', 'system_id': 'smppclient1', 'client_id': '2VU55VT86KHWXTW7X'}
-{'event': 'naz.Client.send_data', 'stage': 'end', 'smpp_command': 'bind_transceiver', 'correlation_id': None, 'msg': 'hello', 'environment': 'production', 'release': 'canary', 'smsc_host': '127.0.0.1', 'system_id': 'smppclient1', 'client_id': '2VU55VT86KHWXTW7X'}
+{'event': 'naz.Client.send_data', 'stage': 'start', 'smpp_command': 'bind_transceiver', 'log_id': None, 'msg': 'hello', 'environment': 'production', 'release': 'canary', 'smsc_host': '127.0.0.1', 'system_id': 'smppclient1', 'client_id': '2VU55VT86KHWXTW7X'}
+{'event': 'naz.SimpleHook.request', 'stage': 'start', 'smpp_command': 'bind_transceiver', 'log_id': None, 'environment': 'production', 'release': 'canary', 'smsc_host': '127.0.0.1', 'system_id': 'smppclient1', 'client_id': '2VU55VT86KHWXTW7X'}
+{'event': 'naz.Client.send_data', 'stage': 'end', 'smpp_command': 'bind_transceiver', 'log_id': None, 'msg': 'hello', 'environment': 'production', 'release': 'canary', 'smsc_host': '127.0.0.1', 'system_id': 'smppclient1', 'client_id': '2VU55VT86KHWXTW7X'}
 {'event': 'naz.Client.tranceiver_bind', 'stage': 'end', 'environment': 'production', 'release': 'canary', 'smsc_host': '127.0.0.1', 'system_id': 'smppclient1', 'client_id': '2VU55VT86KHWXTW7X'}
 {'event': 'naz.Client.send_forever', 'stage': 'start', 'environment': 'production', 'release': 'canary', 'smsc_host': '127.0.0.1', 'system_id': 'smppclient1', 'client_id': '2VU55VT86KHWXTW7X'}
 ```              
@@ -209,10 +209,10 @@ import naz
 from prometheus_client import Counter
 
 class MyPrometheusHook(naz.hooks.BaseHook):
-    async def request(self, smpp_command, correlation_id):
+    async def request(self, smpp_command, log_id):
         c = Counter('my_requests', 'Description of counter')
         c.inc() # Increment by 1
-    async def response(self, smpp_command, correlation_id):
+    async def response(self, smpp_command, log_id):
         c = Counter('my_responses', 'Description of counter')
         c.inc() # Increment by 1
 
@@ -228,13 +228,13 @@ import sqlite3
 import naz
 
 class SetMessageStateHook(naz.hooks.BaseHook):
-    async def request(self, smpp_command, correlation_id):
+    async def request(self, smpp_command, log_id):
         pass
-    async def response(self, smpp_command, correlation_id):
+    async def response(self, smpp_command, log_id):
         if smpp_command == naz.SmppCommand.DELIVER_SM:
             conn = sqlite3.connect('mySmsDB.db')
             c = conn.cursor()
-            t = (correlation_id,)
+            t = (log_id,)
             # watch out for SQL injections!!
             c.execute("UPDATE SmsTable SET State='delivered' WHERE CorrelatinID=?", t)
             conn.commit()
@@ -300,7 +300,7 @@ Your application should enqueue a dictionary/json object with any parameters but
     "version": "1",
     "smpp_command": naz.SmppCommand.SUBMIT_SM,
     "short_message": string,
-    "correlation_id": string,
+    "log_id": string,
     "source_addr": string,
     "destination_addr": string
 }
@@ -344,7 +344,7 @@ for i in range(0, 4):
         "version": "1",
         "smpp_command": naz.SmppCommand.SUBMIT_SM,
         "short_message": "Hello World-{0}".format(str(i)),
-        "correlation_id": "myid12345",
+        "log_id": "myid12345",
         "source_addr": "254722111111",
         "destination_addr": "254722999999",
     }
@@ -413,7 +413,7 @@ for i in range(0, 5):
         "version": "1",
         "smpp_command": naz.SmppCommand.SUBMIT_SM,
         "short_message": "Hello World-{0}".format(str(i)),
-        "correlation_id": "myid12345",
+        "log_id": "myid12345",
         "source_addr": "254722111111",
         "destination_addr": "254722999999",
     }

--- a/documentation/config.md
+++ b/documentation/config.md
@@ -125,7 +125,7 @@ Your application should enqueue a dictionary object with any parameters but the 
     "version": "1",
     "smpp_command": naz.SmppCommand.SUBMIT_SM,
     "short_message": string,
-    "correlation_id": string,
+    "log_id": string,
     "source_addr": string,
     "destination_addr": string
 }

--- a/examples/example_klasses.py
+++ b/examples/example_klasses.py
@@ -146,7 +146,7 @@ if __name__ == "__main__":
             "version": "1",
             "smpp_command": naz.SmppCommand.SUBMIT_SM,
             "short_message": "Hello World-{0}".format(str(i)),
-            "correlation_id": "myid1234-{0}".format(str(i)),
+            "log_id": "myid1234-{0}".format(str(i)),
             "source_addr": "254722111111",
             "destination_addr": "254722999999",
         }

--- a/examples/in_mem_queue_example.py
+++ b/examples/in_mem_queue_example.py
@@ -21,7 +21,7 @@ for i in range(0, 4):
         "version": "1",
         "smpp_command": naz.SmppCommand.SUBMIT_SM,
         "short_message": "Hello World-{0}".format(str(i)),
-        "correlation_id": "myid12345",
+        "log_id": "myid12345",
         "source_addr": "254722111111",
         "destination_addr": "254722999999",
     }
@@ -31,7 +31,7 @@ for i in range(0, 4):
     # loop.run_until_complete(
     #     cli.submit_sm(
     #         short_message="Hello World-{0}".format(str(i)),
-    #         correlation_id="myid12345",
+    #         log_id="myid12345",
     #         source_addr="254722111111",
     #         destination_addr="254722999999",
     #     )

--- a/examples/rabbitmq_queue_example.py
+++ b/examples/rabbitmq_queue_example.py
@@ -135,7 +135,7 @@ item_to_enqueue = {
     "version": "1",
     "smpp_command": naz.SmppCommand.SUBMIT_SM,
     "short_message": "Hello World",
-    "correlation_id": "myid12345",
+    "log_id": "myid12345",
     "source_addr": "254722111111",
     "destination_addr": "254722999999",
 }

--- a/examples/redis_queue_example.py
+++ b/examples/redis_queue_example.py
@@ -79,7 +79,7 @@ for i in range(0, 5):
         "version": "1",
         "smpp_command": naz.SmppCommand.SUBMIT_SM,
         "short_message": "Hello World-{0}".format(str(i)),
-        "correlation_id": "myid12345",
+        "log_id": "myid12345",
         "source_addr": "254722111111",
         "destination_addr": "254722999999",
     }

--- a/naz/__version__.py
+++ b/naz/__version__.py
@@ -2,7 +2,7 @@ about = {
     "__title__": "naz",
     "__description__": "Naz is an SMPP client.",
     "__url__": "https://github.com/komuw/naz",
-    "__version__": "v0.1.0-beta.4",
+    "__version__": "v0.2.0-beta.1",
     "__author__": "komuW",
     "__author_email__": "komuw05@gmail.com",
     "__license__": "MIT",

--- a/naz/client.py
+++ b/naz/client.py
@@ -903,7 +903,6 @@ class Client:
                     smpp_command = item_to_dequeue["smpp_command"]
                     if smpp_command == SmppCommand.SUBMIT_SM:
                         short_message = item_to_dequeue["short_message"]
-                        log_id = item_to_dequeue["log_id"]
                         source_addr = item_to_dequeue["source_addr"]
                         destination_addr = item_to_dequeue["destination_addr"]
                         full_pdu = await self.build_submit_sm_pdu(

--- a/naz/client.py
+++ b/naz/client.py
@@ -299,7 +299,7 @@ class Client:
 
         # dictionary of sequence_number and their corresponding log_id
         # this will be used to track different pdu's and user generated log_id
-        self.seq_correl = {}
+        self.seq_log = {}
 
         # the messages that are published to a queue by either naz
         # or user application should be versioned.
@@ -380,7 +380,7 @@ class Client:
             sequence_number = self.sequence_generator.next_sequence()
             # associate sequence_number with log_id.
             # this will enable us to also associate responses and thus enhancing traceability of all workflows
-            self.seq_correl[sequence_number] = log_id
+            self.seq_log[sequence_number] = log_id
         except Exception as e:
             self.logger.exception(
                 {"event": "naz.Client.tranceiver_bind", "stage": "end", "error": str(e)}
@@ -431,7 +431,7 @@ class Client:
                 sequence_number = self.sequence_generator.next_sequence()
                 # associate sequence_number with log_id.
                 # this will enable us to also associate responses and thus enhancing traceability of all workflows
-                self.seq_correl[sequence_number] = log_id
+                self.seq_log[sequence_number] = log_id
             except Exception as e:
                 self.logger.exception(
                     {
@@ -708,7 +708,7 @@ class Client:
             sequence_number = self.sequence_generator.next_sequence()
             # associate sequence_number with log_id.
             # this will enable us to also associate responses and thus enhancing traceability of all workflows
-            self.seq_correl[sequence_number] = log_id
+            self.seq_log[sequence_number] = log_id
         except Exception as e:
             self.logger.exception(
                 {
@@ -1034,7 +1034,7 @@ class Client:
         command_status = struct.unpack(">I", command_status_header_data)[0]
         sequence_number = struct.unpack(">I", sequence_number_header_data)[0]
         # get associated user supplied log_id if any, free mem while at it.
-        log_id = self.seq_correl.pop(sequence_number, None)
+        log_id = self.seq_log.pop(sequence_number, None)
 
         smpp_command = self.search_by_command_id_code(command_id)
         if not smpp_command:
@@ -1241,7 +1241,7 @@ class Client:
             sequence_number = self.sequence_generator.next_sequence()
             # associate sequence_number with log_id.
             # this will enable us to also associate responses and thus enhancing traceability of all workflows
-            self.seq_correl[sequence_number] = log_id
+            self.seq_log[sequence_number] = log_id
         except Exception as e:
             self.logger.exception(
                 {"event": "naz.Client.unbind", "stage": "end", "error": str(e), "log_id": log_id}

--- a/naz/hooks.py
+++ b/naz/hooks.py
@@ -12,7 +12,7 @@ class BaseHook:
     after a response is received from SMSC.
     """
 
-    async def request(self, smpp_command: str, correlation_id: typing.Optional[str] = None) -> None:
+    async def request(self, smpp_command: str, log_id: typing.Optional[str] = None) -> None:
         """
         called before a request is sent to SMSC.
 
@@ -23,15 +23,13 @@ class BaseHook:
                 submit_sm, submit_sm_resp,
                 deliver_sm, deliver_sm_resp,
                 enquire_link, enquire_link_resp, generic_nack
-        :param correlation_id:                  (mandatory) [str]
+        :param log_id:                  (mandatory) [str]
             an ID that a user's application had previously supplied to user
             to track/correlate different messages.
         """
         raise NotImplementedError("request method must be implemented.")
 
-    async def response(
-        self, smpp_command: str, correlation_id: typing.Optional[str] = None
-    ) -> None:
+    async def response(self, smpp_command: str, log_id: typing.Optional[str] = None) -> None:
         """
         called after a response is received from SMSC.
 
@@ -42,7 +40,7 @@ class BaseHook:
                 submit_sm, submit_sm_resp,
                 deliver_sm, deliver_sm_resp,
                 enquire_link, enquire_link_resp, generic_nack
-        :param correlation_id:                  (mandatory) [str]
+        :param log_id:                  (mandatory) [str]
             an ID that a user's application had previously supplied to user
             to track/correlate different messages.
         """
@@ -57,7 +55,7 @@ class SimpleHook(BaseHook):
     def __init__(self, logger) -> None:
         self.logger: logging.Logger = logger
 
-    async def request(self, smpp_command: str, correlation_id: typing.Optional[str] = None) -> None:
+    async def request(self, smpp_command: str, log_id: typing.Optional[str] = None) -> None:
         """
         hook method that is called just before a request is sent to SMSC.
         """
@@ -66,13 +64,11 @@ class SimpleHook(BaseHook):
                 "event": "naz.SimpleHook.request",
                 "stage": "start",
                 "smpp_command": smpp_command,
-                "correlation_id": correlation_id,
+                "log_id": log_id,
             }
         )
 
-    async def response(
-        self, smpp_command: str, correlation_id: typing.Optional[str] = None
-    ) -> None:
+    async def response(self, smpp_command: str, log_id: typing.Optional[str] = None) -> None:
         """
         hook method that is called just after a response is gotten from SMSC.
         """
@@ -81,6 +77,6 @@ class SimpleHook(BaseHook):
                 "event": "naz.SimpleHook.response",
                 "stage": "start",
                 "smpp_command": smpp_command,
-                "correlation_id": correlation_id,
+                "log_id": log_id,
             }
         )

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -142,30 +142,28 @@ class TestClient(TestCase):
         with mock.patch("naz.q.SimpleOutboundQueue.enqueue", new=AsyncMock()) as mock_naz_enqueue:
             reader, writer = self._run(self.cli.connect())
             self._run(self.cli.tranceiver_bind())
-            correlation_id = "12345"
+            log_id = "12345"
             self._run(
                 self.cli.submit_sm(
                     short_message="hello smpp",
-                    correlation_id=correlation_id,
+                    log_id=log_id,
                     source_addr="9090",
                     destination_addr="254722000111",
                 )
             )
             self.assertTrue(mock_naz_enqueue.mock.called)
-            self.assertEqual(
-                mock_naz_enqueue.mock.call_args[0][1]["correlation_id"], correlation_id
-            )
+            self.assertEqual(mock_naz_enqueue.mock.call_args[0][1]["log_id"], log_id)
             self.assertEqual(
                 mock_naz_enqueue.mock.call_args[0][1]["smpp_command"], naz.SmppCommand.SUBMIT_SM
             )
 
     def test_submit_sm_sending(self):
         with mock.patch("naz.q.SimpleOutboundQueue.dequeue", new=AsyncMock()) as mock_naz_dequeue:
-            correlation_id = "12345"
+            log_id = "12345"
             short_message = "hello smpp"
             mock_naz_dequeue.mock.return_value = {
                 "version": "1",
-                "correlation_id": correlation_id,
+                "log_id": log_id,
                 "short_message": short_message,
                 "smpp_command": naz.SmppCommand.SUBMIT_SM,
                 "source_addr": "2547000000",
@@ -204,7 +202,7 @@ class TestClient(TestCase):
             self._run(
                 self.cli.speficic_handlers(
                     smpp_command=naz.SmppCommand.ENQUIRE_LINK,
-                    correlation_id="correlation_id",
+                    log_id="log_id",
                     command_status=0,
                     sequence_number=sequence_number,
                     total_pdu_length=16,
@@ -221,7 +219,7 @@ class TestClient(TestCase):
             self._run(
                 self.cli.speficic_handlers(
                     smpp_command=naz.SmppCommand.UNBIND,
-                    correlation_id="correlation_id",
+                    log_id="log_id",
                     command_status=0,
                     sequence_number=sequence_number,
                     total_pdu_length=16,
@@ -239,7 +237,7 @@ class TestClient(TestCase):
             self._run(
                 self.cli.speficic_handlers(
                     smpp_command=naz.SmppCommand.DELIVER_SM,
-                    correlation_id="correlation_id",
+                    log_id="log_id",
                     command_status=0,
                     sequence_number=sequence_number,
                     total_pdu_length=16,
@@ -293,11 +291,11 @@ class TestClient(TestCase):
                 throttle_handler=throttle_handler,
             )
 
-            correlation_id = "12345"
+            log_id = "12345"
             short_message = "hello smpp"
             mock_naz_dequeue.mock.return_value = {
                 "version": "1",
-                "correlation_id": correlation_id,
+                "log_id": log_id,
                 "short_message": short_message,
                 "smpp_command": naz.SmppCommand.SUBMIT_SM,
                 "source_addr": "2547000000",
@@ -322,7 +320,7 @@ class TestClient(TestCase):
             self._run(
                 self.cli.speficic_handlers(
                     smpp_command=naz.SmppCommand.DELIVER_SM,
-                    correlation_id="correlation_id",
+                    log_id="log_id",
                     command_status=0,
                     sequence_number=sequence_number,
                     total_pdu_length=16,
@@ -342,7 +340,7 @@ class TestClient(TestCase):
             self._run(
                 self.cli.speficic_handlers(
                     smpp_command=naz.SmppCommand.DELIVER_SM,
-                    correlation_id="correlation_id",
+                    log_id="log_id",
                     command_status=0x00000058,
                     sequence_number=sequence_number,
                     total_pdu_length=16,
@@ -363,7 +361,7 @@ class TestClient(TestCase):
             self.assertEqual(
                 mock_hook_response.mock.call_args[1]["smpp_command"], naz.SmppCommand.SUBMIT_SM_RESP
             )
-            self.assertEqual(mock_hook_response.mock.call_args[1]["correlation_id"], None)
+            self.assertEqual(mock_hook_response.mock.call_args[1]["log_id"], None)
 
     def test_receving_data(self):
         with mock.patch("naz.Client.connect", new=AsyncMock()) as mock_naz_connect:
@@ -389,7 +387,7 @@ class TestClient(TestCase):
             self._run(
                 self.cli.speficic_handlers(
                     smpp_command=naz.SmppCommand.ENQUIRE_LINK,
-                    correlation_id="correlation_id",
+                    log_id="log_id",
                     command_status=0,
                     sequence_number=sequence_number,
                     total_pdu_length=16,
@@ -414,11 +412,11 @@ class TestClient(TestCase):
 
     def test_session_state(self):
         with mock.patch("naz.q.SimpleOutboundQueue.dequeue", new=AsyncMock()) as mock_naz_dequeue:
-            correlation_id = "12345"
+            log_id = "12345"
             short_message = "hello smpp"
             mock_naz_dequeue.mock.return_value = {
                 "version": "1",
-                "correlation_id": correlation_id,
+                "log_id": log_id,
                 "short_message": short_message,
                 "smpp_command": naz.SmppCommand.SUBMIT_SM,
                 "source_addr": "2547000000",


### PR DESCRIPTION
Thank you for contributing to naz.                    
Every contribution to naz is important.                       

                     

Contributor offers to license certain software (a “Contribution” or multiple
“Contributions”) to naz, and naz agrees to accept said Contributions,
under the terms of the MIT License.
Contributor understands and agrees that naz shall have the irrevocable and perpetual right to make
and distribute copies of any Contribution, as well as to create and distribute collective works and
derivative works of any Contribution, under the MIT License.


Now,                   

# What(What have you changed?)
- rename `correlation_id` to `log_id` 
- rename `client.seq_correl` to `client.seq_log`

# Why(Why did you change it?)
- one of the potential early users of `naz` ran into an issue where their app was already using `correlation_id` for other purposes.  
- since `client.seq_correl` was used to relate SMPP sequence_numbers and `correlation_id` it is renamed to reflect the fact that it now relates sequence_numbers and `log_id`'s
- closes: https://github.com/komuw/naz/issues/74

# References:
1. 
