### PR TITLE
issues/78 - hooks should accept other metadata 

### DIFF
--- a/examples/example_klasses.py
+++ b/examples/example_klasses.py
@@ -149,5 +149,6 @@ if __name__ == "__main__":
             "log_id": "myid1234-{0}".format(str(i)),
             "source_addr": "254722111111",
             "destination_addr": "254722999999",
+            "hook_metadata": '{"name": "verizon", "customer_id": 123456}',
         }
         loop.run_until_complete(ExampleRedisQueueInstance.enqueue(item_to_enqueue))

--- a/examples/example_klasses.py
+++ b/examples/example_klasses.py
@@ -149,6 +149,6 @@ if __name__ == "__main__":
             "log_id": "myid1234-{0}".format(str(i)),
             "source_addr": "254722111111",
             "destination_addr": "254722999999",
-            "hook_metadata": '{"name": "verizon", "customer_id": 123456}',
+            "hook_metadata": '{"telco": "verizon", "customer_id": 123456}',
         }
         loop.run_until_complete(ExampleRedisQueueInstance.enqueue(item_to_enqueue))

--- a/naz/__version__.py
+++ b/naz/__version__.py
@@ -2,7 +2,7 @@ about = {
     "__title__": "naz",
     "__description__": "Naz is an SMPP client.",
     "__url__": "https://github.com/komuw/naz",
-    "__version__": "v0.2.0-beta.1",
+    "__version__": "v0.3.0-beta.1",
     "__author__": "komuW",
     "__author_email__": "komuw05@gmail.com",
     "__license__": "MIT",

--- a/naz/client.py
+++ b/naz/client.py
@@ -657,7 +657,7 @@ class Client:
         )
 
     async def build_submit_sm_pdu(
-        self, short_message, log_id, metadata, source_addr, destination_addr
+        self, short_message, log_id, hook_metadata, source_addr, destination_addr
     ):
         self.logger.info(
             {
@@ -710,7 +710,7 @@ class Client:
             sequence_number = self.sequence_generator.next_sequence()
             # associate sequence_number with log_id.
             # this will enable us to also associate responses and thus enhancing traceability of all workflows
-            self.seq_log[sequence_number] = log_id + "." + metadata
+            self.seq_log[sequence_number] = log_id + "." + hook_metadata
         except Exception as e:
             self.logger.exception(
                 {

--- a/naz/hooks.py
+++ b/naz/hooks.py
@@ -1,4 +1,3 @@
-import typing
 import logging
 
 
@@ -12,7 +11,7 @@ class BaseHook:
     after a response is received from SMSC.
     """
 
-    async def request(self, smpp_command: str, log_id: typing.Optional[str] = None) -> None:
+    async def request(self, smpp_command: str, log_id: str) -> None:
         """
         called before a request is sent to SMSC.
 
@@ -29,7 +28,7 @@ class BaseHook:
         """
         raise NotImplementedError("request method must be implemented.")
 
-    async def response(self, smpp_command: str, log_id: typing.Optional[str] = None) -> None:
+    async def response(self, smpp_command: str, log_id: str) -> None:
         """
         called after a response is received from SMSC.
 
@@ -55,7 +54,7 @@ class SimpleHook(BaseHook):
     def __init__(self, logger) -> None:
         self.logger: logging.Logger = logger
 
-    async def request(self, smpp_command: str, log_id: typing.Optional[str] = None) -> None:
+    async def request(self, smpp_command: str, log_id: str) -> None:
         """
         hook method that is called just before a request is sent to SMSC.
         """
@@ -68,7 +67,7 @@ class SimpleHook(BaseHook):
             }
         )
 
-    async def response(self, smpp_command: str, log_id: typing.Optional[str] = None) -> None:
+    async def response(self, smpp_command: str, log_id: str) -> None:
         """
         hook method that is called just after a response is gotten from SMSC.
         """

--- a/naz/hooks.py
+++ b/naz/hooks.py
@@ -1,3 +1,4 @@
+import typing
 import logging
 
 
@@ -11,7 +12,9 @@ class BaseHook:
     after a response is received from SMSC.
     """
 
-    async def request(self, smpp_command: str, log_id: str) -> None:
+    async def request(
+        self, smpp_command: str, log_id: str, hook_metadata: typing.Optional[str] = None
+    ) -> None:
         """
         called before a request is sent to SMSC.
 
@@ -23,12 +26,17 @@ class BaseHook:
                 deliver_sm, deliver_sm_resp,
                 enquire_link, enquire_link_resp, generic_nack
         :param log_id:                  (mandatory) [str]
-            an ID that a user's application had previously supplied to user
+            an ID that a user's application had previously supplied to naz
             to track/correlate different messages.
+        :param hook_metadata:                  (optional) [str]
+            a string that a user's application had previously supplied to naz
+            that it may want to be correlated with the log_id.
         """
         raise NotImplementedError("request method must be implemented.")
 
-    async def response(self, smpp_command: str, log_id: str) -> None:
+    async def response(
+        self, smpp_command: str, log_id: str, hook_metadata: typing.Optional[str] = None
+    ) -> None:
         """
         called after a response is received from SMSC.
 
@@ -40,8 +48,11 @@ class BaseHook:
                 deliver_sm, deliver_sm_resp,
                 enquire_link, enquire_link_resp, generic_nack
         :param log_id:                  (mandatory) [str]
-            an ID that a user's application had previously supplied to user
+            an ID that a user's application had previously supplied to naz
             to track/correlate different messages.
+        :param hook_metadata:                  (optional) [str]
+            a string that a user's application had previously supplied to naz
+            that it may want to be correlated with the log_id.
         """
         raise NotImplementedError("response method must be implemented.")
 
@@ -54,7 +65,9 @@ class SimpleHook(BaseHook):
     def __init__(self, logger) -> None:
         self.logger: logging.Logger = logger
 
-    async def request(self, smpp_command: str, log_id: str) -> None:
+    async def request(
+        self, smpp_command: str, log_id: str, hook_metadata: typing.Optional[str] = None
+    ) -> None:
         """
         hook method that is called just before a request is sent to SMSC.
         """
@@ -64,10 +77,13 @@ class SimpleHook(BaseHook):
                 "stage": "start",
                 "smpp_command": smpp_command,
                 "log_id": log_id,
+                "hook_metadata": hook_metadata,
             }
         )
 
-    async def response(self, smpp_command: str, log_id: str) -> None:
+    async def response(
+        self, smpp_command: str, log_id: str, hook_metadata: typing.Optional[str] = None
+    ) -> None:
         """
         hook method that is called just after a response is gotten from SMSC.
         """
@@ -77,5 +93,6 @@ class SimpleHook(BaseHook):
                 "stage": "start",
                 "smpp_command": smpp_command,
                 "log_id": log_id,
+                "hook_metadata": hook_metadata,
             }
         )


### PR DESCRIPTION
Thank you for contributing to naz.                    
Every contribution to naz is important.                       

                     

Contributor offers to license certain software (a “Contribution” or multiple
“Contributions”) to naz, and naz agrees to accept said Contributions,
under the terms of the MIT License.
Contributor understands and agrees that naz shall have the irrevocable and perpetual right to make
and distribute copies of any Contribution, as well as to create and distribute collective works and
derivative works of any Contribution, under the MIT License.


Now,                   

# What(What have you changed?)
- Have hooks accept an extra parameter(`hook_metadata`)

# Why(Why did you change it?)
- Apps may want to pass additional metadata when they queue messages to the outbound Queue[1] and they would want that metadata passed on when hooks are called. 
- closes: https://github.com/komuw/naz/issues/78

# References:
1. https://github.com/komuw/naz/blob/69e81467035ac1ffac885ab6f29c28fa52c1acb0/naz/q.py#L6
