### PR TITLE
Issues/84 - hook response should not be called before `naz.Client.speficic_handlers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ script:
   - bandit -r --exclude .venv -ll .
   # to find types, use reveal_type eg: reveal_type(asyncio.get_event_loop())
   # see: http://mypy.readthedocs.io/en/latest/common_issues.html#displaying-the-type-of-an-expression
-  - mypy --show-column-numbers -m naz.q -m naz.throttle -m naz.ratelimiter -m naz.hooks -m naz.sequence -m naz.correlater
+  - mypy --show-column-numbers naz/ #--strict
   - naz-cli --version && naz-cli --help
   - naz-cli --config examples/example_config.json --dry-run
   - coverage erase

--- a/Makefile
+++ b/Makefile
@@ -38,4 +38,4 @@ test:
 	@printf "\n run flake8::\n" && flake8 .
 	@printf "\n run pylint::\n" && pylint --enable=E --disable=W,R,C --unsafe-load-any-extension=y examples/ naz/ tests/ cli/
 	@printf "\n run bandit::\n" && bandit -r --exclude .venv -ll .
-	@printf "\n run mypy::\n" && mypy --show-column-numbers -m naz.q -m naz.throttle -m naz.ratelimiter -m naz.hooks -m naz.sequence -m naz.correlater
+	@printf "\n run mypy::\n" && mypy --show-column-numbers --strict naz/

--- a/README.md
+++ b/README.md
@@ -216,8 +216,7 @@ class MyPrometheusHook(naz.hooks.BaseHook):
                        smpp_command,
                        log_id,
                        hook_metadata,
-                       response_code,
-                       response_description):
+                       response_status):
         c = Counter('my_responses', 'Description of counter')
         c.inc() # Increment by 1
 
@@ -239,8 +238,7 @@ class SetMessageStateHook(naz.hooks.BaseHook):
                        smpp_command,
                        log_id,
                        hook_metadata,
-                       response_code,
-                       response_description):
+                       response_status):
         if smpp_command == naz.SmppCommand.DELIVER_SM:
             conn = sqlite3.connect('mySmsDB.db')
             c = conn.cursor()

--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ class MyPrometheusHook(naz.hooks.BaseHook):
                        smpp_command,
                        log_id,
                        hook_metadata,
-                       response_status):
+                       smsc_response):
         c = Counter('my_responses', 'Description of counter')
         c.inc() # Increment by 1
 
@@ -238,7 +238,7 @@ class SetMessageStateHook(naz.hooks.BaseHook):
                        smpp_command,
                        log_id,
                        hook_metadata,
-                       response_status):
+                       smsc_response):
         if smpp_command == naz.SmppCommand.DELIVER_SM:
             conn = sqlite3.connect('mySmsDB.db')
             c = conn.cursor()

--- a/README.md
+++ b/README.md
@@ -209,10 +209,15 @@ import naz
 from prometheus_client import Counter
 
 class MyPrometheusHook(naz.hooks.BaseHook):
-    async def request(self, smpp_command, log_id):
+    async def request(self, smpp_command, log_id, hook_metadata):
         c = Counter('my_requests', 'Description of counter')
         c.inc() # Increment by 1
-    async def response(self, smpp_command, log_id):
+    async def response(self,
+                       smpp_command,
+                       log_id,
+                       hook_metadata,
+                       response_code,
+                       response_description):
         c = Counter('my_responses', 'Description of counter')
         c.inc() # Increment by 1
 
@@ -228,9 +233,14 @@ import sqlite3
 import naz
 
 class SetMessageStateHook(naz.hooks.BaseHook):
-    async def request(self, smpp_command, log_id):
+    async def request(self, smpp_command, log_id, hook_metadata):
         pass
-    async def response(self, smpp_command, log_id):
+    async def response(self,
+                       smpp_command,
+                       log_id,
+                       hook_metadata,
+                       response_code,
+                       response_description):
         if smpp_command == naz.SmppCommand.DELIVER_SM:
             conn = sqlite3.connect('mySmsDB.db')
             c = conn.cursor()

--- a/naz/__init__.py
+++ b/naz/__init__.py
@@ -1,9 +1,12 @@
 from .client import Client  # noqa: F401
 from .client import SmppCommand  # noqa: F401
-from . import nazcodec  # noqa: F401
+from .client import CommandStatus  # noqa: F401
+
 from . import q  # noqa: F401
-from . import ratelimiter  # noqa: F401
-from . import correlater  # noqa: F401
-from . import sequence  # noqa: F401
 from . import throttle  # noqa: F401
+from . import sequence  # noqa: F401
+from . import nazcodec  # noqa: F401
+from . import correlater  # noqa: F401
+from . import ratelimiter  # noqa: F401
+
 from . import __version__  # noqa: F401

--- a/naz/__version__.py
+++ b/naz/__version__.py
@@ -2,7 +2,7 @@ about = {
     "__title__": "naz",
     "__description__": "Naz is an SMPP client.",
     "__url__": "https://github.com/komuw/naz",
-    "__version__": "v0.3.0-beta.1",
+    "__version__": "v0.4.0-beta.1",
     "__author__": "komuW",
     "__author_email__": "komuw05@gmail.com",
     "__license__": "MIT",

--- a/naz/client.py
+++ b/naz/client.py
@@ -145,93 +145,6 @@ class Client:
             SmppCommand.GENERIC_NACK: 0x80000000,
         }
 
-        # see section 5.1.3 of smpp ver 3.4 spec document
-        CommandStatus = collections.namedtuple("CommandStatus", "code description")
-        self.command_statuses = {
-            "ESME_ROK": CommandStatus(0x00000000, "Success"),
-            "ESME_RINVMSGLEN": CommandStatus(0x00000001, "Message Length is invalid"),
-            "ESME_RINVCMDLEN": CommandStatus(0x00000002, "Command Length is invalid"),
-            "ESME_RINVCMDID": CommandStatus(0x00000003, "Invalid Command ID"),
-            "ESME_RINVBNDSTS": CommandStatus(0x00000004, "Incorrect BIND Status for given command"),
-            "ESME_RALYBND": CommandStatus(0x00000005, "ESME Already in Bound State"),
-            "ESME_RINVPRTFLG": CommandStatus(0x00000006, "Invalid Priority Flag"),
-            "ESME_RINVREGDLVFLG": CommandStatus(0x00000007, "Invalid Registered Delivery Flag"),
-            "ESME_RSYSERR": CommandStatus(0x00000008, "System Error"),
-            "Reserved": CommandStatus(0x00000009, "Reserved"),
-            "ESME_RINVSRCADR": CommandStatus(0x0000000A, "Invalid Source Address"),
-            "ESME_RINVDSTADR": CommandStatus(0x0000000B, "Invalid Dest Addr"),
-            "ESME_RINVMSGID": CommandStatus(0x0000000C, "Message ID is invalid"),
-            "ESME_RBINDFAIL": CommandStatus(0x0000000D, "Bind Failed"),
-            "ESME_RINVPASWD": CommandStatus(0x0000000E, "Invalid Password"),
-            "ESME_RINVSYSID": CommandStatus(0x0000000F, "Invalid System ID"),
-            "REserved": CommandStatus(
-                0x00000010, "Reserved"
-            ),  # key has different capitalization to avoid clash
-            "ESME_RCANCELFAIL": CommandStatus(0x00000011, "Cancel SM Failed"),
-            "ReServed": CommandStatus(0x00000012, "Reserved"),
-            "ESME_RREPLACEFAIL": CommandStatus(0x00000013, "Replace SM Failed"),
-            "ESME_RMSGQFUL": CommandStatus(0x00000014, "Message Queue Full"),
-            "ESME_RINVSERTYP": CommandStatus(0x00000015, "Invalid Service Type"),
-            # Reserved 0x00000016 - 0x00000032 Reserved
-            "ESME_RINVNUMDESTS": CommandStatus(0x00000033, "Invalid number of destinations"),
-            "ESME_RINVDLNAME": CommandStatus(0x00000034, "Invalid Distribution List name"),
-            # Reserved 0x00000035 - 0x0000003F Reserved
-            "ESME_RINVDESTFLAG": CommandStatus(
-                0x00000040, "Destination flag is invalid (submit_multi)"
-            ),
-            "ResErved": CommandStatus(0x00000041, "Reserved"),
-            "ESME_RINVSUBREP": CommandStatus(
-                0x00000042,
-                "Invalid (submit with replace) request(i.e. submit_sm with replace_if_present_flag set)",
-            ),
-            "ESME_RINVESMCLASS": CommandStatus(0x00000043, "Invalid esm_class field data"),
-            "ESME_RCNTSUBDL": CommandStatus(0x00000044, "Cannot Submit to Distribution List"),
-            "ESME_RSUBMITFAIL": CommandStatus(0x00000045, "Submit_sm or submit_multi failed"),
-            # Reserved 0x00000046 - 0x00000047 Reserved
-            "ESME_RINVSRCTON": CommandStatus(0x00000048, "Invalid Source address TON"),
-            "ESME_RINVSRCNPI": CommandStatus(0x00000049, "Invalid Source address NPI"),
-            "ESME_RINVDSTTON": CommandStatus(0x00000050, "Invalid Destination address TON"),
-            "ESME_RINVDSTNPI": CommandStatus(0x00000051, "Invalid Destination address NPI"),
-            "ReseRved": CommandStatus(0x00000052, "Reserved"),
-            "ESME_RINVSYSTYP": CommandStatus(0x00000053, "Invalid system_type field"),
-            "ESME_RINVREPFLAG": CommandStatus(0x00000054, "Invalid replace_if_present flag"),
-            "ESME_RINVNUMMSGS": CommandStatus(0x00000055, "Invalid number of messages"),
-            # Reserved 0x00000056 - 0x00000057 Reserved
-            "ESME_RTHROTTLED": CommandStatus(
-                0x00000058, "Throttling error (ESME has exceeded allowed message limits)"
-            ),
-            # Reserved 0x00000059 - 0x00000060 Reserved
-            "ESME_RINVSCHED": CommandStatus(0x00000061, "Invalid Scheduled Delivery Time"),
-            "ESME_RINVEXPIRY": CommandStatus(
-                0x00000062, "Invalid message validity period (Expiry time)"
-            ),
-            "ESME_RINVDFTMSGID": CommandStatus(
-                0x00000063, "Predefined Message Invalid or Not Found"
-            ),
-            "ESME_RX_T_APPN": CommandStatus(0x00000064, "ESME Receiver Temporary App Error Code"),
-            "ESME_RX_P_APPN": CommandStatus(0x00000065, "ESME Receiver Permanent App Error Code"),
-            "ESME_RX_R_APPN": CommandStatus(0x00000066, "ESME Receiver Reject Message Error Code"),
-            "ESME_RQUERYFAIL": CommandStatus(0x00000067, "query_sm request failed"),
-            # Reserved 0x00000068 - 0x000000BF Reserved
-            "ESME_RINVOPTPARSTREAM": CommandStatus(
-                0x000000C0, "Error in the optional part of the PDU Body."
-            ),
-            "ESME_ROPTPARNOTALLWD": CommandStatus(0x000000C1, "Optional Parameter not allowed"),
-            "ESME_RINVPARLEN": CommandStatus(0x000000C2, "Invalid Parameter Length."),
-            "ESME_RMISSINGOPTPARAM": CommandStatus(
-                0x000000C3, "Expected Optional Parameter missing"
-            ),
-            "ESME_RINVOPTPARAMVAL": CommandStatus(0x000000C4, "Invalid Optional Parameter Value"),
-            # Reserved 0x000000C5 - 0x000000FD Reserved
-            "ESME_RDELIVERYFAILURE": CommandStatus(
-                0x000000FE, "Delivery Failure (used for data_sm_resp)"
-            ),
-            "ESME_RUNKNOWNERR": CommandStatus(0x000000FF, "Unknown Error"),
-            # Reserved for SMPP extension 0x00000100 - 0x000003FF Reserved for SMPP extension
-            # Reserved for SMSC vendor specific errors 0x00000400 - 0x000004FF Reserved for SMSC vendor specific errors
-            # Reserved 0x00000500 - 0xFFFFFFFF Reserved
-        }
-
         # see section 5.2.19
         DataCoding = collections.namedtuple("DataCoding", "code description")
         # the keys to the `data_codings` dict are the names of the codecs as defined in https://docs.python.org/3.6/library/codecs.html
@@ -316,10 +229,10 @@ class Client:
         return None
 
     def search_by_command_status_code(self, command_status_code):
-        for key, val in self.command_statuses.items():
-            if val.code == command_status_code:
-                return key, val
-        return None, None
+        for member in SmppCommandStatus:
+            if command_status_code == member.value.value:
+                return member
+        return None
 
     @staticmethod
     def retry_after(current_retries):
@@ -1221,7 +1134,7 @@ class Client:
         """
         # todo: pliz find a better way of doing this.
         # this will cause global warming with useless computation
-        _, command_status_value = self.search_by_command_status_code(command_status)
+        command_status_value = self.search_by_command_status_code(command_status)
 
         if command_status != SmppCommandStatus.ESME_ROK.value:
             # we got an error from SMSC

--- a/naz/client.py
+++ b/naz/client.py
@@ -222,11 +222,9 @@ class Client:
         self.current_session_state = SmppSessionState.CLOSED
 
     def search_by_command_id_code(self, command_id_code):
-        import pdb;pdb.set_trace()
-        for key, val in SmppCommandStatus.__dict__.items():
-            if not key.startswith("__"):
-                if command_id_code == val.value:
-                    return val
+        for key, val in self.command_ids.items():
+            if val == command_id_code:
+                return key
         return None
 
     def search_by_command_status_code(self, command_status_code):

--- a/naz/client.py
+++ b/naz/client.py
@@ -222,6 +222,7 @@ class Client:
         self.current_session_state = SmppSessionState.CLOSED
 
     def search_by_command_id_code(self, command_id_code):
+        import pdb;pdb.set_trace()
         for key, val in SmppCommandStatus.__dict__.items():
             if not key.startswith("__"):
                 if command_id_code == val.value:

--- a/naz/client.py
+++ b/naz/client.py
@@ -1,6 +1,7 @@
 import struct
 import random
 import string
+import typing
 import asyncio
 import logging
 import collections
@@ -1414,10 +1415,7 @@ class SmppCommand:
     GENERIC_NACK = "generic_nack"
 
 
-from typing import NamedTuple
-
-
-class CommandStatus(NamedTuple):
+class CommandStatus(typing.NamedTuple):
     code: str
     value: int
     description: str

--- a/naz/client.py
+++ b/naz/client.py
@@ -293,7 +293,7 @@ class Client:
         command_length = 16 + len(body)  # 16 is for headers
         command_id = self.command_ids[smpp_command]
         # the status for success see section 5.1.3
-        command_status = SmppCommandStatus.ESME_ROK.value
+        command_status = SmppCommandStatus.ESME_ROK.value.value
         try:
             sequence_number = self.sequence_generator.next_sequence()
         except Exception as e:
@@ -332,7 +332,6 @@ class Client:
                 }
             )
 
-        import pdb;pdb.set_trace()
         header = struct.pack(">IIII", command_length, command_id, command_status, sequence_number)
         full_pdu = header + body
         await self.send_data(smpp_command=smpp_command, msg=full_pdu, log_id=log_id)
@@ -461,7 +460,7 @@ class Client:
         # header
         command_length = 16 + len(body)  # 16 is for headers
         command_id = self.command_ids[smpp_command]
-        command_status = SmppCommandStatus.ESME_ROK.value
+        command_status = SmppCommandStatus.ESME_ROK.value.value
         sequence_number = sequence_number
         header = struct.pack(">IIII", command_length, command_id, command_status, sequence_number)
 
@@ -521,7 +520,7 @@ class Client:
         # header
         command_length = 16 + len(body)  # 16 is for headers
         command_id = self.command_ids[smpp_command]
-        command_status = SmppCommandStatus.ESME_ROK.value
+        command_status = SmppCommandStatus.ESME_ROK.value.value
         sequence_number = sequence_number
         header = struct.pack(">IIII", command_length, command_id, command_status, sequence_number)
 
@@ -567,7 +566,7 @@ class Client:
         # header
         command_length = 16 + len(body)  # 16 is for headers
         command_id = self.command_ids[smpp_command]
-        command_status = SmppCommandStatus.ESME_ROK.value
+        command_status = SmppCommandStatus.ESME_ROK.value.value
         sequence_number = sequence_number
         header = struct.pack(">IIII", command_length, command_id, command_status, sequence_number)
 
@@ -1135,9 +1134,10 @@ class Client:
         """
         # todo: pliz find a better way of doing this.
         # this will cause global warming with useless computation
-        command_status_value = self.search_by_command_status_code(command_status)
+        CommandStatus = self.search_by_command_status_code(command_status)
+        import pdb;pdb.set_trace()
 
-        if command_status != SmppCommandStatus.ESME_ROK.value:
+        if CommandStatus.value.value != SmppCommandStatus.ESME_ROK.value.value:
             # we got an error from SMSC
             self.logger.exception(
                 {
@@ -1145,8 +1145,8 @@ class Client:
                     "stage": "start",
                     "smpp_command": smpp_command,
                     "log_id": log_id,
-                    "command_status": command_status_value.code,
-                    "state": command_status_value.description,
+                    "command_status": CommandStatus.value.value,
+                    "state": CommandStatus.value.description,
                 }
             )
         else:
@@ -1156,16 +1156,16 @@ class Client:
                     "stage": "start",
                     "smpp_command": smpp_command,
                     "log_id": log_id,
-                    "command_status": command_status_value.code,
+                    "command_status": CommandStatus.value.value,
                     "state": command_status_value.description,
                 }
             )
 
         try:
             # call throttling handler
-            if command_status == SmppCommandStatus.ESME_ROK.value:
+            if command_status == SmppCommandStatus.ESME_ROK.value.value:
                 await self.throttle_handler.not_throttled()
-            elif command_status == SmppCommandStatus.ESME_RTHROTTLED.value:
+            elif command_status == SmppCommandStatus.ESME_RTHROTTLED.value.value:
                 await self.throttle_handler.throttled()
         except Exception as e:
             self.logger.exception(
@@ -1194,7 +1194,7 @@ class Client:
         elif smpp_command == SmppCommand.BIND_TRANSCEIVER_RESP:
             # the body of `bind_transceiver_resp` only has `system_id` which is a
             # C-Octet String of variable length upto 16 octets
-            if command_status == SmppCommandStatus.ESME_ROK.value:
+            if command_status == SmppCommandStatus.ESME_ROK.value.value:
                 self.current_session_state = SmppSessionState.BOUND_TRX
         elif smpp_command == SmppCommand.UNBIND:
             # we need to handle this since we need to send unbind_resp

--- a/naz/client.py
+++ b/naz/client.py
@@ -1266,9 +1266,6 @@ class Client:
                 }
             )
 
-        import pdb
-
-        pdb.set_trace()
         # call user's hook for responses
         try:
             await self.hook.response(

--- a/naz/client.py
+++ b/naz/client.py
@@ -1491,3 +1491,197 @@ class SmppCommand:
     ENQUIRE_LINK = "enquire_link"
     ENQUIRE_LINK_RESP = "enquire_link_resp"
     GENERIC_NACK = "generic_nack"
+
+
+_commandStatus = collections.namedtuple("CommandStatus", "code value description")
+
+
+class SmppCommandStatus:
+    """
+    see section 5.1.3 of smpp ver 3.4 spec document
+    """
+
+    ESME_ROK = _commandStatus(code="ESME_ROK", value=0x00000000, description="Success")
+    ESME_RINVMSGLEN = _commandStatus(
+        code="ESME_RINVMSGLEN", value=0x00000001, description="Message Length is invalid"
+    )
+    ESME_RINVCMDLEN = _commandStatus(
+        code="ESME_RINVCMDLEN", value=0x00000002, description="Command Length is invalid"
+    )
+    ESME_RINVCMDID = _commandStatus(
+        code="ESME_RINVCMDID", value=0x00000003, description="Invalid Command ID"
+    )
+    ESME_RINVBNDSTS = _commandStatus(
+        code="ESME_RINVBNDSTS",
+        value=0x00000004,
+        description="Incorrect BIND Status for given command",
+    )
+    ESME_RALYBND = _commandStatus(
+        code="ESME_RALYBND", value=0x00000005, description="ESME Already in Bound State"
+    )
+    ESME_RINVPRTFLG = _commandStatus(
+        code="ESME_RINVPRTFLG", value=0x00000006, description="Invalid Priority Flag"
+    )
+    ESME_RINVREGDLVFLG = _commandStatus(
+        code="ESME_RINVREGDLVFLG", value=0x00000007, description="Invalid Registered Delivery Flag"
+    )
+    ESME_RSYSERR = _commandStatus(code="ESME_RSYSERR", value=0x00000008, description="System Error")
+    # Reserved =  _commandStatus(code="Reserved", value=0x00000009,description= "Reserved")
+    ESME_RINVSRCADR = _commandStatus(
+        code="ESME_RINVSRCADR", value=0x0000000A, description="Invalid Source Address"
+    )
+    ESME_RINVSRCADR = _commandStatus(
+        code="ESME_RINVSRCADR", value=0x0000000A, description="Invalid Source Address"
+    )
+    ESME_RINVDSTADR = _commandStatus(
+        code="ESME_RINVDSTADR", value=0x0000000B, description="Invalid Dest Addr"
+    )
+    ESME_RINVMSGID = _commandStatus(
+        code="ESME_RINVMSGID", value=0x0000000C, description="Message ID is invalid"
+    )
+    ESME_RBINDFAIL = _commandStatus(
+        code="ESME_RBINDFAIL", value=0x0000000D, description="Bind Failed"
+    )
+    ESME_RINVPASWD = _commandStatus(
+        code="ESME_RINVPASWD", value=0x0000000E, description="Invalid Password"
+    )
+    ESME_RINVSYSID = _commandStatus(
+        code="ESME_RINVSYSID", value=0x0000000F, description="Invalid System ID"
+    )
+    # Reserved =  _commandStatus(code="Reserved", value=0x00000010,description= "Reserved")
+    ESME_RCANCELFAIL = _commandStatus(
+        code="ESME_RCANCELFAIL", value=0x00000011, description="Cancel SM Failed"
+    )
+    # Reserved =  _commandStatus(code="Reserved", value=0x00000012,description= "Reserved")
+    ESME_RREPLACEFAIL = _commandStatus(
+        code="ESME_RREPLACEFAIL", value=0x00000013, description="Replace SM Failed"
+    )
+    ESME_RMSGQFUL = _commandStatus(
+        code="ESME_RMSGQFUL", value=0x00000014, description="Message Queue Full"
+    )
+    ESME_RINVSERTYP = _commandStatus(
+        code="ESME_RINVSERTYP", value=0x00000015, description="Invalid Service Type"
+    )
+    # Reserved 0x00000016 - 0x00000032 Reserved
+    ESME_RINVNUMDESTS = _commandStatus(
+        code="ESME_RINVNUMDESTS", value=0x00000033, description="Invalid number of destinations"
+    )
+    ESME_RINVDLNAME = _commandStatus(
+        code="ESME_RINVNUMDESTS", value=0x00000034, description="Invalid Distribution List name"
+    )
+    # Reserved 0x00000035 - 0x0000003F Reserved
+    ESME_RINVDESTFLAG = _commandStatus(
+        code="ESME_RINVDESTFLAG",
+        value=0x00000040,
+        description="Destination flag is invalid (submit_multi)",
+    )
+    # Reserved =  _commandStatus(code="Reserved", value=0x00000041,description= "Reserved")
+    ESME_RINVSUBREP = _commandStatus(
+        code="ESME_RINVSUBREP",
+        value=0x00000042,
+        description="Invalid (submit with replace) request(i.e. submit_sm with replace_if_present_flag set)",
+    )
+    ESME_RINVESMCLASS = _commandStatus(
+        code="ESME_RINVESMCLASS", value=0x00000043, description="Invalid esm_class field data"
+    )
+    ESME_RCNTSUBDL = _commandStatus(
+        code="ESME_RCNTSUBDL", value=0x00000044, description="Cannot Submit to Distribution List"
+    )
+    ESME_RSUBMITFAIL = _commandStatus(
+        code="ESME_RSUBMITFAIL", value=0x00000045, description="Submit_sm or submit_multi failed"
+    )
+    # Reserved 0x00000046 - 0x00000047 Reserved
+    ESME_RINVSRCTON = _commandStatus(
+        code="ESME_RINVSRCTON", value=0x00000048, description="Invalid Source address TON"
+    )
+    ESME_RINVSRCNPI = _commandStatus(
+        code="ESME_RINVSRCNPI", value=0x00000049, description="Invalid Source address NPI"
+    )
+    ESME_RINVDSTTON = _commandStatus(
+        code="ESME_RINVDSTTON", value=0x00000050, description="Invalid Destination address TON"
+    )
+    ESME_RINVDSTNPI = _commandStatus(
+        code="ESME_RINVDSTNPI", value=0x00000051, description="Invalid Destination address NPI"
+    )
+    # Reserved =  _commandStatus(code="Reserved", value=0x00000052,description= "Reserved")
+    ESME_RINVSYSTYP = _commandStatus(
+        code="ESME_RINVSYSTYP", value=0x00000053, description="Invalid system_type field"
+    )
+    ESME_RINVREPFLAG = _commandStatus(
+        code="ESME_RINVREPFLAG", value=0x00000054, description="Invalid replace_if_present flag"
+    )
+    ESME_RINVNUMMSGS = _commandStatus(
+        code="ESME_RINVNUMMSGS", value=0x00000055, description="Invalid number of messages"
+    )
+    # Reserved 0x00000056 - 0x00000057 Reserved
+    ESME_RTHROTTLED = _commandStatus(
+        code="ESME_RTHROTTLED",
+        value=0x00000058,
+        description="Throttling error (ESME has exceeded allowed message limits)",
+    )
+    # Reserved 0x00000059 - 0x00000060 Reserved
+    ESME_RINVSCHED = _commandStatus(
+        code="ESME_RINVSCHED", value=0x00000061, description="Invalid Scheduled Delivery Time"
+    )
+    ESME_RINVEXPIRY = _commandStatus(
+        code="ESME_RINVEXPIRY",
+        value=0x00000062,
+        description="Invalid message validity period (Expiry time)",
+    )
+    ESME_RINVDFTMSGID = _commandStatus(
+        code="ESME_RINVDFTMSGID",
+        value=0x00000063,
+        description="Predefined Message Invalid or Not Found",
+    )
+    ESME_RX_T_APPN = _commandStatus(
+        code="ESME_RX_T_APPN",
+        value=0x00000064,
+        description="ESME Receiver Temporary App Error Code",
+    )
+    ESME_RX_P_APPN = _commandStatus(
+        code="ESME_RX_P_APPN",
+        value=0x00000065,
+        description="ESME Receiver Permanent App Error Code",
+    )
+    ESME_RX_R_APPN = _commandStatus(
+        code="ESME_RX_R_APPN",
+        value=0x00000066,
+        description="ESME Receiver Reject Message Error Code",
+    )
+    ESME_RQUERYFAIL = _commandStatus(
+        code="ESME_RQUERYFAIL", value=0x00000067, description="query_sm request failed"
+    )
+    # Reserved 0x00000068 - 0x000000BF Reserved
+    ESME_RINVOPTPARSTREAM = _commandStatus(
+        code="ESME_RINVOPTPARSTREAM",
+        value=0x000000C0,
+        description="Error in the optional part of the PDU Body.",
+    )
+    ESME_ROPTPARNOTALLWD = _commandStatus(
+        code="ESME_ROPTPARNOTALLWD", value=0x000000C1, description="Optional Parameter not allowed"
+    )
+    ESME_RINVPARLEN = _commandStatus(
+        code="ESME_RINVPARLEN", value=0x000000C2, description="Invalid Parameter Length."
+    )
+    ESME_RMISSINGOPTPARAM = _commandStatus(
+        code="ESME_RMISSINGOPTPARAM",
+        value=0x000000C3,
+        description="Expected Optional Parameter missing",
+    )
+    ESME_RINVOPTPARAMVAL = _commandStatus(
+        code="ESME_RINVOPTPARAMVAL",
+        value=0x000000C4,
+        description="Invalid Optional Parameter Value",
+    )
+    # Reserved 0x000000C5 - 0x000000FD Reserved
+    ESME_RDELIVERYFAILURE = _commandStatus(
+        code="ESME_RDELIVERYFAILURE",
+        value=0x000000FE,
+        description="Delivery Failure (used for data_sm_resp)",
+    )
+    ESME_RUNKNOWNERR = _commandStatus(
+        code="ESME_RUNKNOWNERR", value=0x000000FF, description="Unknown Error"
+    )
+    # Reserved for SMPP extension 0x00000100 - 0x000003FF Reserved for SMPP extension
+    # Reserved for SMSC vendor specific errors 0x00000400 - 0x000004FF Reserved for SMSC vendor specific errors
+    # Reserved 0x00000500 - 0xFFFFFFFF Reserved

--- a/naz/client.py
+++ b/naz/client.py
@@ -1442,9 +1442,6 @@ class SmppCommandStatus(enum.Enum):
     ESME_RINVSRCADR = _commandStatus(
         code="ESME_RINVSRCADR", value=0x0000000A, description="Invalid Source Address"
     )
-    ESME_RINVSRCADR = _commandStatus(
-        code="ESME_RINVSRCADR", value=0x0000000A, description="Invalid Source Address"
-    )
     ESME_RINVDSTADR = _commandStatus(
         code="ESME_RINVDSTADR", value=0x0000000B, description="Invalid Dest Addr"
     )

--- a/naz/client.py
+++ b/naz/client.py
@@ -227,10 +227,12 @@ class Client:
                 return key
         return None
 
+
     def search_by_command_status_code(self, command_status_code):
-        for member in SmppCommandStatus:
-            if command_status_code == member.value.value:
-                return member
+        for key, val in SmppCommandStatus.__dict__.items():
+            if not key.startswith("__"):
+                if command_status_code == val.value:
+                    return val
         return None
 
     @staticmethod
@@ -1134,6 +1136,7 @@ class Client:
         # todo: pliz find a better way of doing this.
         # this will cause global warming with useless computation
         CommandStatus = self.search_by_command_status_code(command_status)
+        import pdb;pdb.set_trace()
 
         if CommandStatus.value.value != SmppCommandStatus.ESME_ROK.value:
             # we got an error from SMSC

--- a/naz/client.py
+++ b/naz/client.py
@@ -332,6 +332,7 @@ class Client:
                 }
             )
 
+        import pdb;pdb.set_trace()
         header = struct.pack(">IIII", command_length, command_id, command_status, sequence_number)
         full_pdu = header + body
         await self.send_data(smpp_command=smpp_command, msg=full_pdu, log_id=log_id)
@@ -1372,7 +1373,7 @@ class NazLoggingAdapter(logging.LoggerAdapter):
             return "{0}".format(merged_log_event), kwargs
 
 
-class SmppSessionState(enum.Enum):
+class SmppSessionState:
     """
     see section 2.2 of SMPP spec document v3.4
     we are ignoring the other states since we are only concerning ourselves with an ESME in Transceiver mode.
@@ -1387,7 +1388,7 @@ class SmppSessionState(enum.Enum):
     CLOSED = "CLOSED"
 
 
-class SmppCommand(enum.Enum):
+class SmppCommand:
     """
     see section 4 of SMPP spec document v3.4
     """

--- a/naz/client.py
+++ b/naz/client.py
@@ -1275,7 +1275,7 @@ class Client:
                 smpp_command=smpp_command,
                 log_id=log_id,
                 hook_metadata=hook_metadata,
-                response_status=commandStatus,
+                smsc_response=commandStatus,
             )
         except Exception as e:
             self.logger.exception(
@@ -1417,12 +1417,14 @@ class SmppCommand:
     GENERIC_NACK = "generic_nack"
 
 
-
 from typing import NamedTuple
+
+
 class CommandStatus(NamedTuple):
     code: str
     value: int
     description: str
+
 
 class _SmppCommandStatus:
     """

--- a/naz/correlater.py
+++ b/naz/correlater.py
@@ -1,4 +1,5 @@
 import time
+from typing import Tuple
 
 
 class BaseCorrelater:
@@ -29,7 +30,7 @@ class BaseCorrelater:
         """
         raise NotImplementedError("put method must be implemented.")
 
-    async def get(self, sequence_number: str) -> (str, str):
+    async def get(self, sequence_number: str) -> Tuple[str, str]:
         """
         called by naz to get the correlation of a given SMPP sequence number to log_id and/or hook_metadata.
 
@@ -87,7 +88,7 @@ class SimpleCorrelater(BaseCorrelater):
         # garbage collect
         await self.delete_after_ttl()
 
-    async def get(self, sequence_number: str) -> (str, str):
+    async def get(self, sequence_number: str) -> Tuple[str, str]:
         """
         get relation of SMPP sequence_number and log_id and/or hook_metadata
         """
@@ -101,7 +102,7 @@ class SimpleCorrelater(BaseCorrelater):
         await self.delete_after_ttl()
         return item["log_id"], item["hook_metadata"]
 
-    async def delete_after_ttl(self):
+    async def delete_after_ttl(self) -> None:
         """
         iterate over all stored items and delete any that are
         older than self.max_ttl seconds

--- a/naz/hooks.py
+++ b/naz/hooks.py
@@ -36,11 +36,7 @@ class BaseHook:
         raise NotImplementedError("request method must be implemented.")
 
     async def response(
-        self,
-        smpp_command: str,
-        log_id: str,
-        hook_metadata: str,
-        response_status: "naz.CommandStatus",
+        self, smpp_command: str, log_id: str, hook_metadata: str, smsc_response: "naz.CommandStatus"
     ) -> None:
         """
         called after a response is received from SMSC.
@@ -58,7 +54,7 @@ class BaseHook:
         :param hook_metadata:                  (optional) [str]
             a string that a user's application had previously supplied to naz
             that it may want to be correlated with the log_id.
-        :param response_status:                  (optional) [naz.client.CommandStatus]
+        :param smsc_response:                  (optional) [naz.CommandStatus]
             the response from SMSC.
         """
         raise NotImplementedError("response method must be implemented.")
@@ -87,20 +83,11 @@ class SimpleHook(BaseHook):
         )
 
     async def response(
-        self,
-        smpp_command: str,
-        log_id: str,
-        hook_metadata: str,
-        response_status: "naz.CommandStatus",
+        self, smpp_command: str, log_id: str, hook_metadata: str, smsc_response: "naz.CommandStatus"
     ) -> None:
         """
         hook method that is called just after a response is gotten from SMSC.
         """
-        import pdb
-
-        pdb.set_trace()
-        # type(response_status) ==  naz.client.CommandStatus or
-        # type(response_status) ==  naz.CommandStatus
         self.logger.info(
             {
                 "event": "naz.SimpleHook.response",
@@ -108,6 +95,6 @@ class SimpleHook(BaseHook):
                 "smpp_command": smpp_command,
                 "log_id": log_id,
                 "hook_metadata": hook_metadata,
-                "response_status": response_status,
+                "smsc_response": smsc_response,
             }
         )

--- a/naz/hooks.py
+++ b/naz/hooks.py
@@ -95,6 +95,6 @@ class SimpleHook(BaseHook):
                 "smpp_command": smpp_command,
                 "log_id": log_id,
                 "hook_metadata": hook_metadata,
-                "smsc_response": smsc_response,
+                "smsc_response": smsc_response.description,
             }
         )

--- a/naz/hooks.py
+++ b/naz/hooks.py
@@ -1,4 +1,3 @@
-import typing
 import logging
 
 
@@ -12,9 +11,7 @@ class BaseHook:
     after a response is received from SMSC.
     """
 
-    async def request(
-        self, smpp_command: str, log_id: str, hook_metadata: typing.Optional[str] = None
-    ) -> None:
+    async def request(self, smpp_command: str, log_id: str, hook_metadata: str) -> None:
         """
         called before a request is sent to SMSC.
 
@@ -35,7 +32,12 @@ class BaseHook:
         raise NotImplementedError("request method must be implemented.")
 
     async def response(
-        self, smpp_command: str, log_id: str, hook_metadata: typing.Optional[str] = None
+        self,
+        smpp_command: str,
+        log_id: str,
+        hook_metadata: str,
+        response_code: int,
+        response_description: str,
     ) -> None:
         """
         called after a response is received from SMSC.
@@ -53,6 +55,10 @@ class BaseHook:
         :param hook_metadata:                  (optional) [str]
             a string that a user's application had previously supplied to naz
             that it may want to be correlated with the log_id.
+        :param response_code:                  (optional) [int]
+            the response code from SMSC.
+        :param response_description:                  (optional) [str]
+            description of what the response_code means.
         """
         raise NotImplementedError("response method must be implemented.")
 
@@ -65,9 +71,7 @@ class SimpleHook(BaseHook):
     def __init__(self, logger) -> None:
         self.logger: logging.Logger = logger
 
-    async def request(
-        self, smpp_command: str, log_id: str, hook_metadata: typing.Optional[str] = None
-    ) -> None:
+    async def request(self, smpp_command: str, log_id: str, hook_metadata: str) -> None:
         """
         hook method that is called just before a request is sent to SMSC.
         """
@@ -82,7 +86,12 @@ class SimpleHook(BaseHook):
         )
 
     async def response(
-        self, smpp_command: str, log_id: str, hook_metadata: typing.Optional[str] = None
+        self,
+        smpp_command: str,
+        log_id: str,
+        hook_metadata: str,
+        response_code: int,
+        response_description: str,
     ) -> None:
         """
         hook method that is called just after a response is gotten from SMSC.

--- a/naz/hooks.py
+++ b/naz/hooks.py
@@ -40,7 +40,7 @@ class BaseHook:
         smpp_command: str,
         log_id: str,
         hook_metadata: str,
-        response_status: "naz.client.CommandStatus",
+        response_status: "naz.CommandStatus",
     ) -> None:
         """
         called after a response is received from SMSC.
@@ -91,7 +91,7 @@ class SimpleHook(BaseHook):
         smpp_command: str,
         log_id: str,
         hook_metadata: str,
-        response_status: "naz.client.CommandStatus",
+        response_status: "naz.CommandStatus",
     ) -> None:
         """
         hook method that is called just after a response is gotten from SMSC.

--- a/naz/hooks.py
+++ b/naz/hooks.py
@@ -2,7 +2,7 @@ import logging
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    import naz
+    import naz  # noqa: F401
 
 
 class BaseHook:

--- a/naz/hooks.py
+++ b/naz/hooks.py
@@ -1,4 +1,8 @@
 import logging
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import naz
 
 
 class BaseHook:
@@ -36,8 +40,7 @@ class BaseHook:
         smpp_command: str,
         log_id: str,
         hook_metadata: str,
-        response_code: int,
-        response_description: str,
+        response_status: "naz.client.CommandStatus",
     ) -> None:
         """
         called after a response is received from SMSC.
@@ -55,10 +58,8 @@ class BaseHook:
         :param hook_metadata:                  (optional) [str]
             a string that a user's application had previously supplied to naz
             that it may want to be correlated with the log_id.
-        :param response_code:                  (optional) [int]
-            the response code from SMSC.
-        :param response_description:                  (optional) [str]
-            description of what the response_code means.
+        :param response_status:                  (optional) [naz.client.CommandStatus]
+            the response from SMSC.
         """
         raise NotImplementedError("response method must be implemented.")
 
@@ -90,12 +91,16 @@ class SimpleHook(BaseHook):
         smpp_command: str,
         log_id: str,
         hook_metadata: str,
-        response_code: int,
-        response_description: str,
+        response_status: "naz.client.CommandStatus",
     ) -> None:
         """
         hook method that is called just after a response is gotten from SMSC.
         """
+        import pdb
+
+        pdb.set_trace()
+        # type(response_status) ==  naz.client.CommandStatus or
+        # type(response_status) ==  naz.CommandStatus
         self.logger.info(
             {
                 "event": "naz.SimpleHook.response",
@@ -103,5 +108,6 @@ class SimpleHook(BaseHook):
                 "smpp_command": smpp_command,
                 "log_id": log_id,
                 "hook_metadata": hook_metadata,
+                "response_status": response_status,
             }
         )

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -204,7 +204,7 @@ class TestClient(TestCase):
             self._run(
                 self.cli.speficic_handlers(
                     smpp_command=naz.SmppCommand.ENQUIRE_LINK,
-                    command_status=0,
+                    command_status_value=0,
                     sequence_number=sequence_number,
                     log_id="log_id",
                     hook_metadata="hook_metadata",
@@ -222,7 +222,7 @@ class TestClient(TestCase):
             self._run(
                 self.cli.speficic_handlers(
                     smpp_command=naz.SmppCommand.UNBIND,
-                    command_status=0,
+                    command_status_value=0,
                     sequence_number=sequence_number,
                     log_id="log_id",
                     hook_metadata="hook_metadata",
@@ -240,7 +240,7 @@ class TestClient(TestCase):
             self._run(
                 self.cli.speficic_handlers(
                     smpp_command=naz.SmppCommand.DELIVER_SM,
-                    command_status=0,
+                    command_status_value=0,
                     sequence_number=sequence_number,
                     log_id="log_id",
                     hook_metadata="hook_metadata",
@@ -323,7 +323,7 @@ class TestClient(TestCase):
             self._run(
                 self.cli.speficic_handlers(
                     smpp_command=naz.SmppCommand.DELIVER_SM,
-                    command_status=0,
+                    command_status_value=0,
                     sequence_number=sequence_number,
                     log_id="log_id",
                     hook_metadata="hook_metadata",
@@ -343,7 +343,7 @@ class TestClient(TestCase):
             self._run(
                 self.cli.speficic_handlers(
                     smpp_command=naz.SmppCommand.DELIVER_SM,
-                    command_status=0x00000058,
+                    command_status_value=0x00000058,
                     sequence_number=sequence_number,
                     log_id="log_id",
                     hook_metadata="hook_metadata",
@@ -425,7 +425,7 @@ class TestClient(TestCase):
             self._run(
                 self.cli.speficic_handlers(
                     smpp_command=naz.SmppCommand.ENQUIRE_LINK,
-                    command_status=0,
+                    command_status_value=0,
                     sequence_number=sequence_number,
                     log_id="log_id",
                     hook_metadata="hook_metadata",

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -504,7 +504,8 @@ class TestClient(TestCase):
     def test_correlater_get_called(self):
         with mock.patch(
             "naz.correlater.SimpleCorrelater.get", new=AsyncMock()
-        ) as mock_correlater_get, mock.patch("naz.Client.speficic_handlers", new=AsyncMock()):
+        ) as mock_correlater_get:
+            mock_correlater_get.return_value = "log_id", "hook_metadata"
             self._run(
                 self.cli.parse_response_pdu(
                     pdu=b"\x00\x00\x00\x18\x80\x00\x00\t\x00\x00\x00\x00\x00\x00\x00\x06SMPPSim\x00"

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -204,12 +204,13 @@ class TestClient(TestCase):
             self._run(
                 self.cli.speficic_handlers(
                     smpp_command=naz.SmppCommand.ENQUIRE_LINK,
-                    log_id="log_id",
                     command_status=0,
                     sequence_number=sequence_number,
-                    total_pdu_length=16,
+                    log_id="log_id",
+                    hook_metadata="hook_metadata",
                 )
             )
+
             self.assertTrue(mock_naz_enquire_link_resp.mock.called)
             self.assertEqual(
                 mock_naz_enquire_link_resp.mock.call_args[1]["sequence_number"], sequence_number
@@ -221,10 +222,10 @@ class TestClient(TestCase):
             self._run(
                 self.cli.speficic_handlers(
                     smpp_command=naz.SmppCommand.UNBIND,
-                    log_id="log_id",
                     command_status=0,
                     sequence_number=sequence_number,
-                    total_pdu_length=16,
+                    log_id="log_id",
+                    hook_metadata="hook_metadata",
                 )
             )
             self.assertTrue(mock_naz_send_data.mock.called)
@@ -239,10 +240,10 @@ class TestClient(TestCase):
             self._run(
                 self.cli.speficic_handlers(
                     smpp_command=naz.SmppCommand.DELIVER_SM,
-                    log_id="log_id",
                     command_status=0,
                     sequence_number=sequence_number,
-                    total_pdu_length=16,
+                    log_id="log_id",
+                    hook_metadata="hook_metadata",
                 )
             )
             self.assertTrue(mock_naz_enqueue.mock.called)
@@ -322,10 +323,10 @@ class TestClient(TestCase):
             self._run(
                 self.cli.speficic_handlers(
                     smpp_command=naz.SmppCommand.DELIVER_SM,
-                    log_id="log_id",
                     command_status=0,
                     sequence_number=sequence_number,
-                    total_pdu_length=16,
+                    log_id="log_id",
+                    hook_metadata="hook_metadata",
                 )
             )
             self.assertTrue(mock_not_throttled.mock.called)
@@ -342,10 +343,10 @@ class TestClient(TestCase):
             self._run(
                 self.cli.speficic_handlers(
                     smpp_command=naz.SmppCommand.DELIVER_SM,
-                    log_id="log_id",
                     command_status=0x00000058,
                     sequence_number=sequence_number,
-                    total_pdu_length=16,
+                    log_id="log_id",
+                    hook_metadata="hook_metadata",
                 )
             )
             self.assertTrue(mock_throttled.mock.called)
@@ -424,10 +425,10 @@ class TestClient(TestCase):
             self._run(
                 self.cli.speficic_handlers(
                     smpp_command=naz.SmppCommand.ENQUIRE_LINK,
-                    log_id="log_id",
                     command_status=0,
                     sequence_number=sequence_number,
-                    total_pdu_length=16,
+                    log_id="log_id",
+                    hook_metadata="hook_metadata",
                 )
             )
             self.assertTrue(mock_naz_enqueue.mock.called)


### PR DESCRIPTION
Thank you for contributing to naz.                    
Every contribution to naz is important.                       

                     

Contributor offers to license certain software (a “Contribution” or multiple
“Contributions”) to naz, and naz agrees to accept said Contributions,
under the terms of the MIT License.
Contributor understands and agrees that naz shall have the irrevocable and perpetual right to make
and distribute copies of any Contribution, as well as to create and distribute collective works and
derivative works of any Contribution, under the MIT License.


Now,                   

# What(What have you changed?)
- make naz hook for response be called after response from SMSC has been parsed
- pass in the parsed SMSC response to the naz hook for response

# Why(Why did you change it?)
- It makes sense to inform the naz hooks for response about the SMSC response.
  This makes it possible for user applications to decide what to do depending on different SMSC responses
- closes: https://github.com/komuw/naz/issues/84

# References:
1. 
