### PR TITLE
make sure the command length header data be 4 bytes

### DIFF
--- a/naz/client.py
+++ b/naz/client.py
@@ -1852,6 +1852,12 @@ class Client:
                 # `client.reader` and `client.writer` should not have timeouts since they are non-blocking
                 # https://github.com/komuw/naz/issues/116
                 command_length_header_data = await self.reader.read(4)
+
+                # make sure the header data be 4 bytes
+                while len(command_length_header_data) != 4:
+                    more_bytes = await self.reader.read(4 - len(command_length_header_data))
+                    command_length_header_data = command_length_header_data + more_bytes
+
             except (
                 ConnectionError,
                 TimeoutError,


### PR DESCRIPTION
Thank you for contributing to naz.                    
Every contribution to naz is important.                       

                     

Contributor offers to license certain software (a “Contribution” or multiple
“Contributions”) to naz, and naz agrees to accept said Contributions,
under the terms of the MIT License.
Contributor understands and agrees that naz shall have the irrevocable and perpetual right to make
and distribute copies of any Contribution, as well as to create and distribute collective works and
derivative works of any Contribution, under the MIT License.


Now,                   

# What(What have you changed?)
- when receiving data from SMSC, make sure the `command_length_header_data` be 4 bytes

Git diff:
```diff
diff --git a/naz/client.py b/naz/client.py
index 0a83916..fe8f3d4 100644
--- a/naz/client.py
+++ b/naz/client.py
@@ -1852,6 +1852,12 @@ class Client:
                 # `client.reader` and `client.writer` should not have timeouts since they are non-blocking
                 # https://github.com/komuw/naz/issues/116
                 command_length_header_data = await self.reader.read(4)
+
+                # make sure the header data be 4 bytes
+                while len(command_length_header_data) != 4:
+                    more_bytes = await self.reader.read(4 - len(command_length_header_data))
+                    command_length_header_data = command_length_header_data + more_bytes
+
             except (
                 ConnectionError,
                 TimeoutError,

```

# Why(Why did you change it?)
- `self.reader.read(4)` will not ensure the bytes length be 4, if so, the `struct.unpack(">I", command_length_header_data)` will throw an exception with message: unpack requires a buffer of 4 bytes

> I faced the issue when I am doing a stress testing with SMSC, in which case, the naz client will receive larget amount of MO message from SMSC, after running correctly for about 5 minutes, the exception `unpack requires a buffer of 4 bytes` occurred.
> The naz client only read 1 byte from SMSC socket connection even there has more data after.

> So I made this update, and the stress test goes well, for now.


# References:
1. 
