### PR TITLE
Read exactly the entire 16bytes smpp header

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,6 +1,9 @@
 [flake8]
 max-line-length = 150
-# ignore = E125, E123, E251
+
+# ignore this flake8 warnings since they are not pep8 compliant.
+# see `black` documentation
+ignore = E203, E266, E501, W503
 exclude =
     # No need to traverse our git directory
     .git,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 most recent version is listed first.
 
 
+## **version:** v0.6.6
+- make sure that `naz` reads exactly the first 4bytes of an smpp header: https://github.com/komuw/naz/pull/153  
+  - if `naz` is unable to read exactly those bytes, it unbinds and closes the connection
+  - this is so as to ensure that `naz` behaves correctly and does not enter into an inconsistent state.
+- make sire that `naz` reads exacly the first 16bytes of the smpp header: https://github.com/komuw/naz/pull/155   
+  - this builds on the [earlier work](https://github.com/komuw/naz/pull/153) but now `naz` takes it a step further and will unbind & close connection if it is unable to read the entire SMPP header
+  - this is done to prevent inconsistency and also to try and be faithful to the smpp spec.
+
 ## **version:** v0.6.5
 - Simplify Breach log handler: https://github.com/komuw/naz/pull/152
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ most recent version is listed first.
   - this builds on the [earlier work](https://github.com/komuw/naz/pull/153) but now `naz` takes it a step further and will unbind & close connection if it is unable to read the entire SMPP header
   - this is done to prevent inconsistency and also to try and be faithful to the smpp spec.
 
+
 ## **version:** v0.6.5
 - Simplify Breach log handler: https://github.com/komuw/naz/pull/152
 

--- a/naz/__version__.py
+++ b/naz/__version__.py
@@ -2,7 +2,7 @@ about = {
     "__title__": "naz",
     "__description__": "Naz is an async SMPP client.",
     "__url__": "https://github.com/komuw/naz",
-    "__version__": "v0.6.5",
+    "__version__": "v0.6.6",
     "__author__": "komuW",
     "__author_email__": "komuw05@gmail.com",
     "__license__": "MIT",

--- a/naz/client.py
+++ b/naz/client.py
@@ -1849,7 +1849,6 @@ class Client:
                     # make mypy happy; https://github.com/python/mypy/issues/4805
                     assert isinstance(self.reader, asyncio.streams.StreamReader)
 
-                # TODO: look at `pause_reading` and `resume_reading` methods
                 # `client.reader` and `client.writer` should not have timeouts since they are non-blocking
                 # https://github.com/komuw/naz/issues/116
                 header_data = await self.reader.readexactly(self._header_pdu_length)

--- a/naz/client.py
+++ b/naz/client.py
@@ -1867,7 +1867,7 @@ class Client:
                     },
                 )
                 header_data == b""
-                # close connection. it will be automatically reconnect later
+                # close connection. it will be automatically reconnected later
                 await self._unbind_and_disconnect()
             except (
                 ConnectionError,

--- a/naz/client.py
+++ b/naz/client.py
@@ -1869,6 +1869,9 @@ class Client:
                 header_data == b""
                 # close connection. it will be automatically reconnected later
                 await self._unbind_and_disconnect()
+                if TESTING:
+                    # offer escape hatch for tests to come out of endless loop
+                    return header_data
             except (
                 ConnectionError,
                 TimeoutError,

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -37,16 +37,23 @@ class MockStreamReader:
     def __init__(self, pdu):
         self.pdu = pdu
 
+        blocks = []
+        blocks.append(self.pdu)
+        self.data = b"".join(blocks)
+
     async def read(self, n_index=-1):
         if n_index == 0:
             return b""
-        blocks = []
-        blocks.append(self.pdu)
-        data = b"".join(blocks)
-        if n_index == 4:
-            return data[:n_index]
+
+        if n_index == -1:
+            _to_read_data = self.data  # read all data
+            _remaining_data = b""
         else:
-            return data[4:]
+            _to_read_data = self.data[:n_index]
+            _remaining_data = self.data[n_index:]
+
+        self.data = _remaining_data
+        return _to_read_data
 
 
 class TestClient(TestCase):

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -24,14 +24,39 @@ def AsyncMock(*args, **kwargs):
     return mock_coro
 
 
+class MockStreamWriter:
+    """
+    This is a mock of python's StreamWriter;
+    https://docs.python.org/3.6/library/asyncio-stream.html#asyncio.StreamWriter
+    """
+
+    def __init__(self, _is_closing=True):
+        self.transport = self._create_transport(_is_closing=_is_closing)
+
+    async def drain(self):
+        pass
+
+    def close(self):
+        pass
+
+    def _create_transport(self, _is_closing):
+        class MockTransport:
+            def __init__(self, _is_closing):
+                self._is_closing = _is_closing
+
+            def set_write_buffer_limits(self, n):
+                pass
+
+            def is_closing(self):
+                return self._is_closing
+
+        return MockTransport(_is_closing=_is_closing)
+
+
 class MockStreamReader:
     """
     This is a mock of python's StreamReader;
     https://docs.python.org/3.6/library/asyncio-stream.html#asyncio.StreamReader
-
-    We mock the reader having a succesful submit_sm_resp PDU.
-    For the first read we return the first 4bytes,
-    the second read, we return the remaining bytes.
     """
 
     def __init__(self, pdu):
@@ -491,10 +516,25 @@ class TestClient(TestCase):
                 b"\x00\x00\x00\x12\x80\x00\x00\x04\x00\x00\x00\x00\x00\x00\x00\x030\x00"
             )
 
-            # TODO: also create a MockStreamWriter
             mock_naz_connect.mock.return_value = (
                 MockStreamReader(pdu=submit_sm_resp_pdu),
-                "MockStreamWriter",
+                MockStreamWriter(),
+            )
+
+            reader, writer = self._run(self.cli.connect())
+            self.cli.reader = reader
+            self.cli.writer = writer
+            received_pdu = self._run(self.cli.receive_data(TESTING=True))
+            self.assertEqual(received_pdu, submit_sm_resp_pdu)
+
+    # TODO: rename and make work
+    def test_cool(self):
+        with mock.patch("naz.Client.connect", new=AsyncMock()) as mock_naz_connect:
+            submit_sm_resp_pdu = b"\x00\x00\x00"
+
+            mock_naz_connect.mock.return_value = (
+                MockStreamReader(pdu=submit_sm_resp_pdu),
+                MockStreamWriter(),
             )
 
             reader, writer = self._run(self.cli.connect())

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -41,16 +41,27 @@ class MockStreamReader:
         blocks.append(self.pdu)
         self.data = b"".join(blocks)
 
-    async def read(self, n_index=-1):
-        if n_index == 0:
+    async def read(self, n=-1):
+        if n == 0:
             return b""
 
-        if n_index == -1:
+        if n == -1:
             _to_read_data = self.data  # read all data
             _remaining_data = b""
         else:
-            _to_read_data = self.data[:n_index]
-            _remaining_data = self.data[n_index:]
+            _to_read_data = self.data[:n]
+            _remaining_data = self.data[n:]
+
+        self.data = _remaining_data
+        return _to_read_data
+
+    async def readexactly(self, n):
+        _to_read_data = self.data[:n]
+        _remaining_data = self.data[n:]
+
+        if len(_to_read_data) != n:
+            # unable to read exactly n bytes
+            raise asyncio.IncompleteReadError(partial=_to_read_data, expected=n)
 
         self.data = _remaining_data
         return _to_read_data


### PR DESCRIPTION
Thank you for contributing to naz.                    
Every contribution to naz is important.                       

                     

Contributor offers to license certain software (a “Contribution” or multiple
“Contributions”) to naz, and naz agrees to accept said Contributions,
under the terms of the MIT License.
Contributor understands and agrees that naz shall have the irrevocable and perpetual right to make
and distribute copies of any Contribution, as well as to create and distribute collective works and
derivative works of any Contribution, under the MIT License.


Now,                   

# What(What have you changed?)
- make sire that `naz` reads exacly the first 16bytes of the smpp header  
  this builds on the earlier work; https://github.com/komuw/naz/pull/153 but now `naz` takes it a step further and will unbind & close connection if it is unable to read the entire SMPP header

# Why(Why did you change it?)
-  this is done to prevent inconsistency and also to try and be faithful to the smpp spec.
- updates; https://github.com/komuw/naz/issues/135
- Other[1] smpp clients also do something similar

# References:
1. https://github.com/fiorix/go-smpp/blob/6dbf72b9bcea72cea4a035e3a2fc434c4dabaae7/smpp/pdu/header.go#L67-L73
