### PR TITLE
issues/197: During shutdown, close the writer & not reader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ most recent version is listed first.
 
 
 
+## **version:** v0.7.9
+- During shutdown, only close the writer without closing the reader end of the transport: https://github.com/komuw/naz/pull/198
+
+
 ## **version:** v0.7.8
 - Rename `naz.Client.rateLimiter` to `naz.Client.rate_limiter`: https://github.com/komuw/naz/pull/195      
   This was done so as to maintain consistency with other `naz.Client` attributes.    

--- a/naz/__version__.py
+++ b/naz/__version__.py
@@ -2,7 +2,7 @@ about = {
     "__title__": "naz",
     "__description__": "Naz is an async SMPP client.",
     "__url__": "https://github.com/komuw/naz",
-    "__version__": "v0.7.8",
+    "__version__": "v0.7.9",
     "__author__": "komuW",
     "__author_email__": "komuw05@gmail.com",
     "__license__": "MIT",

--- a/naz/client.py
+++ b/naz/client.py
@@ -2315,7 +2315,7 @@ class Client:
             await self.unbind()
             async with self.drain_lock:
                 await self.writer.drain()
-            self.writer.close()
+            self.writer.write_eof()
         except (
             ConnectionError,
             TimeoutError,


### PR DESCRIPTION
Thank you for contributing to naz.                    
Every contribution to naz is important.                       

                     

Contributions are under the [MIT License](https://github.com/komuw/naz/blob/master/LICENSE.txt).



Answer the following questions,                   


# What(What have you changed?)
- During shutdown, close the writer & not reader end of the transport protocol

# Why(Why did you change it?)
- Fixes: https://github.com/komuw/naz/issues/197
- `naz.Client.writer.close()` also closes the transport, on which both the `naz.Client.writer` and 
  `naz.Client.reader` are based on. This means that the reader is also closed. 
   This may not be what we want. When we call `naz.Client.shutdown()` we want to close the writer, 
   however; we want to still be able to read. This is because the SMSC may still send the `UNBIND_RESP` and we want to receive it

# References:
1. 
