### PR TITLE
issues/203: Bugfix - RuntimeError: Cannot call write() after write_eof()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ most recent version is listed first.
 
 
 ## **version:** v0.8.0
+- Bugfix - RuntimeError: Cannot call `write()` after `write_eof()`: https://github.com/komuw/naz/pull/208   
 - support Smpp Optional Tags in `submit_sm`: https://github.com/komuw/naz/pull/202, https://github.com/komuw/naz/pull/207  
 - Fixed some flaky tests: https://github.com/komuw/naz/pull/204, https://github.com/komuw/naz/pull/206  
 - Add ability to use different codecs for different messages while using the same `naz` client: https://github.com/komuw/naz/pull/201   

--- a/docs/_modules/naz/client.html
+++ b/docs/_modules/naz/client.html
@@ -2522,6 +2522,7 @@
             <span class="k">async</span> <span class="k">with</span> <span class="bp">self</span><span class="o">.</span><span class="n">drain_lock</span><span class="p">:</span>
                 <span class="k">await</span> <span class="bp">self</span><span class="o">.</span><span class="n">writer</span><span class="o">.</span><span class="n">drain</span><span class="p">()</span>
             <span class="bp">self</span><span class="o">.</span><span class="n">writer</span><span class="o">.</span><span class="n">write_eof</span><span class="p">()</span>
+            <span class="bp">self</span><span class="o">.</span><span class="n">writer</span> <span class="o">=</span> <span class="kc">None</span>
         <span class="k">except</span> <span class="p">(</span>
             <span class="ne">ConnectionError</span><span class="p">,</span>
             <span class="ne">TimeoutError</span><span class="p">,</span>

--- a/naz/client.py
+++ b/naz/client.py
@@ -2357,6 +2357,7 @@ class Client:
             async with self.drain_lock:
                 await self.writer.drain()
             self.writer.write_eof()
+            self.writer = None
         except (
             ConnectionError,
             TimeoutError,

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1084,10 +1084,14 @@ class TestClient(TestCase):
         """
         self._run(self.cli.connect())
         self._run(self.cli.tranceiver_bind())
+        self.assertIsNotNone(self.cli.writer)
 
         self._run(self.cli._unbind_and_disconnect())
+        self.assertIsNone(self.cli.writer)
+
         self._run(
             self.cli.send_data(
                 smpp_command=naz.SmppCommand.SUBMIT_SM, msg=b"someMessage", log_id="log_id"
             )
         )
+        self.assertIsNotNone(self.cli.writer)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1072,3 +1072,22 @@ class TestClient(TestCase):
                 mock_naz_enqueue.mock.call_args[0][1].smpp_command, naz.SmppCommand.SUBMIT_SM
             )
             self.assertEqual(mock_naz_enqueue.mock.call_args[0][1].short_message, short_message)
+
+    def test_issues_203(self):
+        """
+        test to prove we have fixed: https://github.com/komuw/naz/issues/203
+
+        1. connect to smsc
+        2. bind
+        3. unbind & disconnect
+        4. send `submit_sm`
+        """
+        self._run(self.cli.connect())
+        self._run(self.cli.tranceiver_bind())
+
+        self._run(self.cli._unbind_and_disconnect())
+        self._run(
+            self.cli.send_data(
+                smpp_command=naz.SmppCommand.SUBMIT_SM, msg=b"someMessage", log_id="log_id"
+            )
+        )


### PR DESCRIPTION
Thank you for contributing to naz.                    
Every contribution to naz is important.                       

                     

Contributions are under the [MIT License](https://github.com/komuw/naz/blob/master/LICENSE.txt).



Answer the following questions,                   


# What(What have you changed?)
- Bugfix - RuntimeError: Cannot call write() after write_eof()

# Why(Why did you change it?)
- Fixes: https://github.com/komuw/naz/issues/203

# References:
1. 
